### PR TITLE
Reorder Progress and Body sections

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/AnalyticsScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/AnalyticsScreen.kt
@@ -128,6 +128,15 @@ fun AnalyticsScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         item {
+            InsightCard(
+                state = progressInsightState,
+                isAiConfigured = isAiConfigured,
+                onRequestInsight = onRequestInsight,
+                onOpenChat = onOpenChat
+            )
+        }
+
+        item {
             SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
                 options.forEachIndexed { index, label ->
                     SegmentedButton(
@@ -193,15 +202,6 @@ fun AnalyticsScreen(
         }
 
         item { ExerciseCard(exerciseSummaries = exerciseSummaries) }
-
-        item {
-            InsightCard(
-                state = progressInsightState,
-                isAiConfigured = isAiConfigured,
-                onRequestInsight = onRequestInsight,
-                onOpenChat = onOpenChat
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/ProfileScreen.kt
@@ -160,17 +160,6 @@ fun BodyScreen(
             onManage = onManageSavedFoods
         )
 
-        SectionCard(title = "Body basics") {
-            NumberField("Current weight (kg)", weight.value, decimal = true) { weight.value = it }
-            LabeledDropdown("Activity level", activity.value, ACTIVITY_OPTIONS) { activity.value = it }
-            LabeledDropdown("Goal", goal.value, GOAL_OPTIONS) { goal.value = it }
-        }
-
-        LatestReadingCard(
-            latest = latestMeasurement,
-            onAddReading = { showAddReading = true }
-        )
-
         AiTargetsCard(
             targetCalories = targetCalories.value,
             targetProtein = targetProtein.value,
@@ -194,6 +183,17 @@ fun BodyScreen(
                 )
             }
         )
+
+        LatestReadingCard(
+            latest = latestMeasurement,
+            onAddReading = { showAddReading = true }
+        )
+
+        SectionCard(title = "Body basics") {
+            NumberField("Current weight (kg)", weight.value, decimal = true) { weight.value = it }
+            LabeledDropdown("Activity level", activity.value, ACTIVITY_OPTIONS) { activity.value = it }
+            LabeledDropdown("Goal", goal.value, GOAL_OPTIONS) { goal.value = it }
+        }
 
         Button(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -150,7 +150,7 @@ data class ProgressChatMessage(
 
 enum class ProgressChatRole { USER, ASSISTANT }
 
-/** State of the AI progress-insight card shown at the bottom of Progress. */
+/** State of the AI progress-insight card shown at the top of Progress. */
 @Immutable
 data class ProgressInsightUiState(
     val isLoading: Boolean = false,


### PR DESCRIPTION
## Summary
- Move AI Progress Coach to the top of the Progress tab
- On Body: place Daily targets under Food library, and Body basics under Body composition

## Test plan
- [x] Open Progress — confirm AI Progress Coach is the first card
- [x] Open Body — confirm order: Food library → Daily targets → Body composition → Body basics
- [x] Spot-check that Generate insight / Ask coach and target editing still work