### PR TITLE
Release: F-Droid Latest guard and update heartbeat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,8 @@ jobs:
           VERSION_NAME: ${{ steps.version.outputs.version_name }}
           VERSION_CODE: ${{ steps.version.outputs.version_code }}
 
+      # make_latest: true — this channel owns /releases/latest (site + in-app updates).
+      # F-Droid tags use a separate workflow with make_latest: false.
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
@@ -116,6 +118,7 @@ jobs:
           body: ${{ steps.notes.outputs.notes }}
           draft: false
           prerelease: false
+          make_latest: true
           generate_release_notes: false
           files: |
             app/build/outputs/apk/release/FitBuddy-${{ steps.version.outputs.version_name }}.apk

--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -92,3 +92,10 @@ Outputs:
 
 Edit `versionCode` and `versionName` in `app/build.gradle.kts` before each store upload.
 Local/dev builds keep the fallback versions; CI sets them via `-PappVersionCode` / `-PappVersionName`.
+
+## 7. GitHub “Latest” vs F-Droid
+
+CI releases on `main` (`v*-buildN`, with `FitBuddy-latest.apk`) own GitHub **Latest** —
+the website and in-app updater use those. F-Droid publishes clean `vX.Y.Z` tags as
+**prerelease** with `make_latest: false` (see `fdroid` branch workflow); F-Droid installs
+via the tag `Binaries` URL only, never `/releases/latest`.

--- a/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
+++ b/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
@@ -132,7 +132,8 @@ class FitBuddyApp : Application() {
     }
 
     /**
-     * On upgrade: one "FitBuddy update heartbeat". Otherwise the usual once-per-UTC-day pulse.
+     * On upgrade: one "FitBuddy update heartbeat" (independent of the daily pulse).
+     * Otherwise / additionally the usual once-per-UTC-day pulse.
      * Fresh installs only seed the stored version code (no update pulse).
      */
     private suspend fun maybeSendHeartbeats() {
@@ -149,12 +150,10 @@ class FitBuddyApp : Application() {
             settingsRepository.setLastKnownVersionCode(current)
         } else if (current > previous) {
             if (CrashReporter.sendHeartbeat(info, HeartbeatKind.UPDATE)) {
-                settingsRepository.markHeartbeatSent(today)
                 settingsRepository.setLastKnownVersionCode(current)
-                return
             }
             // Leave previous unset on failure so the next cold start retries the update pulse.
-            return
+            // Update pulse is independent of the daily once-per-UTC-day gate.
         } else if (current != previous) {
             // Downgrade / same-channel swap — sync without an update pulse.
             settingsRepository.setLastKnownVersionCode(current)

--- a/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
+++ b/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
@@ -3,6 +3,7 @@ package com.anant.fitbuddy
 import android.app.Application
 import com.anant.fitbuddy.crash.CrashReporter
 import com.anant.fitbuddy.crash.HeartbeatInfo
+import com.anant.fitbuddy.crash.HeartbeatKind
 import com.anant.fitbuddy.data.backup.BackupManager
 import com.anant.fitbuddy.data.backup.mongo.MongoBackupScheduler
 import com.anant.fitbuddy.data.database.AppDatabase
@@ -118,7 +119,7 @@ class FitBuddyApp : Application() {
         }
         if (settings.crashReportingEnabled) {
             Thread({
-                runBlocking(Dispatchers.IO) { maybeSendDailyHeartbeat() }
+                runBlocking(Dispatchers.IO) { maybeSendHeartbeats() }
             }, "fitbuddy-heartbeat").start()
         }
     }
@@ -130,15 +131,37 @@ class FitBuddyApp : Application() {
         runCatching { repository.uploadMongoBackup() }
     }
 
-    private suspend fun maybeSendDailyHeartbeat() {
-        val today = LocalDate.now(ZoneOffset.UTC).toString()
-        if (settingsRepository.lastHeartbeatUtcDay() == today) return
+    /**
+     * On upgrade: one "FitBuddy update heartbeat". Otherwise the usual once-per-UTC-day pulse.
+     * Fresh installs only seed the stored version code (no update pulse).
+     */
+    private suspend fun maybeSendHeartbeats() {
         val settings = settingsRepository.settings.first()
         val info = HeartbeatInfo(
             aiProvider = settings.provider.name,
             username = settings.usernameForHeartbeat
         )
-        if (CrashReporter.sendDailyHeartbeat(info)) {
+        val today = LocalDate.now(ZoneOffset.UTC).toString()
+        val current = BuildConfig.VERSION_CODE
+        val previous = settingsRepository.lastKnownVersionCode()
+
+        if (previous == null) {
+            settingsRepository.setLastKnownVersionCode(current)
+        } else if (current > previous) {
+            if (CrashReporter.sendHeartbeat(info, HeartbeatKind.UPDATE)) {
+                settingsRepository.markHeartbeatSent(today)
+                settingsRepository.setLastKnownVersionCode(current)
+                return
+            }
+            // Leave previous unset on failure so the next cold start retries the update pulse.
+            return
+        } else if (current != previous) {
+            // Downgrade / same-channel swap — sync without an update pulse.
+            settingsRepository.setLastKnownVersionCode(current)
+        }
+
+        if (settingsRepository.lastHeartbeatUtcDay() == today) return
+        if (CrashReporter.sendHeartbeat(info, HeartbeatKind.DAILY)) {
             settingsRepository.markHeartbeatSent(today)
         }
     }

--- a/app/src/main/java/com/anant/fitbuddy/crash/CrashReporter.kt
+++ b/app/src/main/java/com/anant/fitbuddy/crash/CrashReporter.kt
@@ -33,6 +33,24 @@ data class HeartbeatInfo(
     val model: String = Build.MODEL.orEmpty().take(64)
 )
 
+/** Why a fleet pulse was sent — maps to the Sentry log message string. */
+enum class HeartbeatKind {
+    DAILY,
+    CONFETTI,
+    UPDATE;
+
+    val logMessage: String
+        get() = when (this) {
+            DAILY -> "FitBuddy daily heartbeat"
+            CONFETTI -> "FitBuddy confetti heartbeat"
+            UPDATE -> "FitBuddy update heartbeat"
+        }
+
+    /** Love-tap may send even when crash reporting is off. */
+    val bypassReportingToggle: Boolean
+        get() = this == CONFETTI
+}
+
 /**
  * Thin Sentry wrapper: crashes/ANRs, optional daily heartbeat check-ins, no PII.
  * Empty [BuildConfig.SENTRY_DSN] keeps the SDK uninitialized (local builds without a key).
@@ -67,8 +85,7 @@ object CrashReporter {
                 // Heartbeats use Logs/Metrics only — never promote them to Issues.
                 val msg = event.message?.formatted
                 if (event.fingerprints?.contains(HEARTBEAT_MONITOR_SLUG) == true ||
-                    msg == MESSAGE_DAILY_HEARTBEAT ||
-                    msg == MESSAGE_CONFETTI_HEARTBEAT
+                    HeartbeatKind.entries.any { it.logMessage == msg }
                 ) {
                     return@BeforeSendCallback null
                 }
@@ -103,14 +120,14 @@ object CrashReporter {
     }
 
     /**
-     * Anonymous daily heartbeat: Crons check-in (OK) plus Metrics/Logs with device/app/AI
+     * Anonymous heartbeat: Crons check-in (OK) plus Metrics/Logs with device/app/AI
      * attributes for fleet breakdown (Explore → Metrics / Logs — not Issues).
-     * Call at most once per UTC day when reporting is on. Returns true if the check-in was sent.
-     * Pass [force] to send even when crash reporting is off (easter-egg love tap).
+     * Callers gate once-per-day / once-per-update. Returns true if the check-in was sent.
+     * [HeartbeatKind.CONFETTI] may send even when crash reporting is off (love tap).
      */
-    fun sendDailyHeartbeat(info: HeartbeatInfo, force: Boolean = false): Boolean {
+    fun sendHeartbeat(info: HeartbeatInfo, kind: HeartbeatKind = HeartbeatKind.DAILY): Boolean {
         if (!ready.get()) return false
-        if (!reportingEnabled && !force) return false
+        if (!reportingEnabled && !kind.bypassReportingToggle) return false
         return runCatching {
             val checkIn = CheckIn(HEARTBEAT_MONITOR_SLUG, CheckInStatus.OK).apply {
                 release =
@@ -127,10 +144,7 @@ object CrashReporter {
                 }
             }
             val checkInId = Sentry.captureCheckIn(checkIn)
-            emitFleetPulse(
-                info,
-                message = if (force) MESSAGE_CONFETTI_HEARTBEAT else MESSAGE_DAILY_HEARTBEAT
-            )
+            emitFleetPulse(info, message = kind.logMessage)
             // Flush so cold-start pulse isn't lost if the process is killed early.
             Sentry.flush(5_000L)
             checkInId != SentryId.EMPTY_ID
@@ -138,6 +152,10 @@ object CrashReporter {
             Log.e(TAG, "heartbeat failed", e)
         }.getOrDefault(false)
     }
+
+    /** @see sendHeartbeat */
+    fun sendDailyHeartbeat(info: HeartbeatInfo, force: Boolean = false): Boolean =
+        sendHeartbeat(info, if (force) HeartbeatKind.CONFETTI else HeartbeatKind.DAILY)
 
     /**
      * One count per active install/day, tagged for grouping in Explore → Metrics
@@ -173,8 +191,6 @@ object CrashReporter {
     }
 
     private const val TAG = "FitBuddyCrash"
-    private const val MESSAGE_DAILY_HEARTBEAT = "FitBuddy daily heartbeat"
-    private const val MESSAGE_CONFETTI_HEARTBEAT = "FitBuddy confetti heartbeat"
 
     private fun scrub(event: SentryEvent): SentryEvent {
         event.request = null

--- a/app/src/main/java/com/anant/fitbuddy/data/backup/BackupSettings.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/backup/BackupSettings.kt
@@ -14,7 +14,7 @@ import com.squareup.moshi.JsonClass
  * - [AppSettings.mongoLastUploadAt] / [AppSettings.mongoLastUploadOk] / [AppSettings.mongoLastError]
  * - [AppSettings.lastSuccessfulBackupAt]
  * - Atlas connection URI (build-baked via MongoUriVault — never in backup JSON)
- * - Sentry heartbeat day, in-flight OAuth PKCE verifier
+ * - Sentry heartbeat day, last-known version code, in-flight OAuth PKCE verifier
  *
  * Active API key strings ([AppSettings.openRouterApiKey] etc.) are derived from the key lists
  * on restore via [AppSettings.withKeys].

--- a/app/src/main/java/com/anant/fitbuddy/data/model/ProgressInsightNormalize.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/model/ProgressInsightNormalize.kt
@@ -1,0 +1,140 @@
+package com.anant.fitbuddy.data.model
+
+/**
+ * Some models smash the JSON schema into the summary string, e.g.
+ * `…priority.','recommendations':['Do X.','Do Y.']`. Recover a clean summary + list so the UI
+ * can show recommendations as separate bullets.
+ *
+ * Never throws: bad recovery input returns [this] unchanged.
+ */
+fun ProgressInsightResponse.normalized(): ProgressInsightResponse =
+    runCatching {
+        val recovered = recoverEmbeddedRecommendations(summary) ?: return this
+        copy(
+            summary = recovered.first,
+            recommendations = recommendations.ifEmpty { recovered.second },
+            bodyScore = bodyScore ?: recovered.third
+        )
+    }.getOrDefault(this)
+
+/** @return Triple(cleanSummary, recommendations, bodyScore?) or null if nothing embedded. */
+private fun recoverEmbeddedRecommendations(
+    summary: String
+): Triple<String, List<String>, Int?>? {
+    val marker = findRecommendationsMarker(summary) ?: return null
+    val cleanSummary = summary.substring(0, marker).trim()
+        .trimEnd(',', ' ', '\'', '"')
+        .trim()
+    if (cleanSummary.isEmpty()) return null
+
+    var rest = summary.substring(marker)
+    val bracket = rest.indexOf('[')
+    if (bracket < 0) return null
+    rest = rest.substring(bracket + 1)
+
+    var bodyScore: Int? = null
+    val scoreIdx = indexOfBodyScoreField(rest)
+    if (scoreIdx != null) {
+        val afterColon = rest.substring(scoreIdx)
+        val value = afterColon.substringBefore(',').substringBefore('}').trim()
+            .trim('\'', '"', ' ')
+        bodyScore = value.takeIf { it != "null" }?.toIntOrNull()
+        rest = rest.substring(0, scoreIdx).trimEnd(',', ' ', '\'', '"')
+    }
+    val listEnd = rest.lastIndexOf(']')
+    val listBody = (if (listEnd >= 0) rest.substring(0, listEnd) else rest).trim()
+    val embeddedRecs = splitEmbeddedStringList(listBody)
+    // Always return a cleaned summary once the smash marker is found — models often leave a
+    // truncated `,'recommendations':[` tail in summary while still filling the real array field.
+    if (cleanSummary == summary.trim()) return null
+    return Triple(cleanSummary, embeddedRecs, bodyScore)
+}
+
+/**
+ * Index of the start of an embedded `,'recommendations':[` / `,"recommendations":[` fragment,
+ * or null. Plain [String] scans only — Android's [Regex] rejects some patterns that pass on the JVM
+ * (notably `}?`), and that used to crash insight generation with a blank error.
+ */
+private fun findRecommendationsMarker(summary: String): Int? {
+    val lower = summary.lowercase()
+    val key = "recommendations"
+    var from = 0
+    while (true) {
+        val keyAt = lower.indexOf(key, from)
+        if (keyAt < 0) return null
+        var i = keyAt - 1
+        while (i >= 0 && lower[i].isWhitespace()) i--
+        if (i >= 0 && (lower[i] == '\'' || lower[i] == '"')) i--
+        while (i >= 0 && lower[i].isWhitespace()) i--
+        val commaAt = i
+        if (commaAt >= 0 && lower[commaAt] == ',') {
+            var j = keyAt + key.length
+            if (j < lower.length && (lower[j] == '\'' || lower[j] == '"')) j++
+            while (j < lower.length && lower[j].isWhitespace()) j++
+            if (j < lower.length && lower[j] == ':') {
+                j++
+                while (j < lower.length && lower[j].isWhitespace()) j++
+                if (j < lower.length && lower[j] == '[') {
+                    var start = commaAt
+                    if (start > 0 && (summary[start - 1] == '\'' || summary[start - 1] == '"')) {
+                        start--
+                    }
+                    return start
+                }
+            }
+        }
+        from = keyAt + key.length
+    }
+}
+
+/** Index of `,body_score:` / `"body_score":` inside [rest], or null. */
+private fun indexOfBodyScoreField(rest: String): Int? {
+    val lower = rest.lowercase()
+    val key = "body_score"
+    var from = 0
+    while (true) {
+        val keyAt = lower.indexOf(key, from)
+        if (keyAt < 0) return null
+        var j = keyAt + key.length
+        if (j < lower.length && (lower[j] == '\'' || lower[j] == '"')) j++
+        while (j < lower.length && lower[j].isWhitespace()) j++
+        if (j < lower.length && lower[j] == ':') {
+            // Prefer cuts that look like a trailing field (comma or quote before the key).
+            var i = keyAt - 1
+            while (i >= 0 && lower[i].isWhitespace()) i--
+            if (i >= 0 && (lower[i] == '\'' || lower[i] == '"')) i--
+            while (i >= 0 && lower[i].isWhitespace()) i--
+            if (i < 0 || lower[i] == ',' || lower[i] == '[') {
+                return j + 1
+            }
+        }
+        from = keyAt + key.length
+    }
+}
+
+/** Splits `'a','b'` / `"a","b"` list bodies from mangled model output. */
+private fun splitEmbeddedStringList(body: String): List<String> {
+    if (body.isBlank()) return emptyList()
+    val out = ArrayList<String>()
+    var i = 0
+    while (i < body.length) {
+        while (i < body.length && body[i] in " \t\n\r,[") i++
+        if (i >= body.length) break
+        val quote = body[i]
+        if (quote == '\'' || quote == '"') {
+            i++
+            val start = i
+            while (i < body.length && body[i] != quote) i++
+            out.add(body.substring(start, i).trim())
+            if (i < body.length) i++
+        } else {
+            val start = i
+            while (i < body.length && body[i] != ',') i++
+            val piece = body.substring(start, i).trim().trimEnd(']')
+            if (piece.isNotBlank()) out.add(piece)
+        }
+        while (i < body.length && body[i] != ',') i++
+        if (i < body.length && body[i] == ',') i++
+    }
+    return out.filter { it.isNotBlank() }
+}

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/GithubApi.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/GithubApi.kt
@@ -2,8 +2,15 @@ package com.anant.fitbuddy.data.remote
 
 import com.anant.fitbuddy.data.remote.dto.GithubReleaseDto
 import retrofit2.http.GET
+import retrofit2.http.Query
 
 interface GithubApi {
-    @GET("repos/anantdark/FitBuddy/releases/latest")
-    suspend fun getLatestRelease(): GithubReleaseDto
+    /**
+     * Lists releases newest-first. Prefer this over `/releases/latest` so F-Droid tags
+     * (`vX.Y.Z`, no `-buildN`) never become the in-app update target.
+     */
+    @GET("repos/anantdark/FitBuddy/releases")
+    suspend fun listReleases(
+        @Query("per_page") perPage: Int = 30
+    ): List<GithubReleaseDto>
 }

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/NetworkModule.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/NetworkModule.kt
@@ -53,7 +53,9 @@ object NetworkModule {
         OkHttpClient.Builder()
             .addInterceptor(loggingInterceptor)
             .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
+            // Reasoning / free-tier models often stream a long "thinking" body after HTTP 200.
+            .readTimeout(180, TimeUnit.SECONDS)
+            .callTimeout(210, TimeUnit.SECONDS)
             .build()
     }
 

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
@@ -9,6 +9,7 @@ import com.anant.fitbuddy.data.model.ProgressChatTurn
 import com.anant.fitbuddy.data.model.ProgressInsightResponse
 import com.anant.fitbuddy.data.model.TargetPlanResponse
 import com.anant.fitbuddy.data.model.WorkoutCaloriesResponse
+import com.anant.fitbuddy.data.model.normalized
 import com.anant.fitbuddy.data.remote.dto.ChatErrorDto
 import com.anant.fitbuddy.data.remote.dto.ChatMessage
 import com.anant.fitbuddy.data.remote.dto.ChatMessagePlain
@@ -102,7 +103,7 @@ class RemoteAiDataSource(
         compressedMetrics: String
     ): ProgressInsightResponse {
         val json = completeToJson(settings, buildProgressPrompt(compressedMetrics), null)
-        return parseJson(progressInsightAdapter, json)
+        return parseJson(progressInsightAdapter, json).normalized()
     }
 
     /**
@@ -771,12 +772,13 @@ class RemoteAiDataSource(
         if BODY30 / body_measurements has fewer than 2 readings or lacks enough fields to judge.
 
         Respond with a SINGLE JSON object and nothing else (no markdown fences, no commentary),
-        EXACTLY this schema:
+        EXACTLY this schema (double quotes only; never embed recommendations inside summary):
         {
           "summary": "String (2-4 sentences)",
           "recommendations": ["String", "String"],
           "body_score": Int or null
         }
+        "summary" must be plain prose only. Put each tip as its own string in "recommendations".
 
         User progress data (compressed):
         $compressedMetrics

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/UpdateChecker.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/UpdateChecker.kt
@@ -1,5 +1,7 @@
 package com.anant.fitbuddy.data.remote
 
+import com.anant.fitbuddy.data.remote.dto.GithubReleaseDto
+
 /** Result of comparing the latest GitHub release against the running build. */
 sealed interface UpdateCheckResult {
     data class Available(
@@ -16,7 +18,8 @@ sealed interface UpdateCheckResult {
 
 /**
  * Sideload-friendly update check: the app isn't Play Store distributed, so we query the repo's
- * latest GitHub release directly instead of relying on a store update prompt.
+ * GitHub Releases for the newest **CI** build (`v*-buildN`) instead of relying on a store
+ * update prompt. F-Droid tags (`vX.Y.Z`) are ignored — those binaries are for the store only.
  */
 class UpdateChecker(private val api: GithubApi) {
 
@@ -26,7 +29,9 @@ class UpdateChecker(private val api: GithubApi) {
 
     suspend fun checkForUpdate(currentVersionCode: Int): UpdateCheckResult {
         return try {
-            val release = api.getLatestRelease()
+            val release = api.listReleases().firstOrNull(::isCiSideloadRelease)
+                ?: return UpdateCheckResult.Error("No GitHub CI release with an APK found")
+
             val remoteVersionCode = buildNumberRegex.find(release.tagName)
                 ?.groupValues
                 ?.get(1)
@@ -37,7 +42,8 @@ class UpdateChecker(private val api: GithubApi) {
                 return UpdateCheckResult.UpToDate
             }
 
-            val apkAsset = release.assets.firstOrNull { it.name.endsWith(".apk") }
+            val apkAsset = release.assets.firstOrNull { it.name == "FitBuddy-latest.apk" }
+                ?: release.assets.firstOrNull { it.name.endsWith(".apk") }
                 ?: return UpdateCheckResult.Error("Latest release has no APK attached")
 
             UpdateCheckResult.Available(
@@ -53,5 +59,12 @@ class UpdateChecker(private val api: GithubApi) {
         } catch (e: Exception) {
             UpdateCheckResult.Error(e.message ?: "Update check failed")
         }
+    }
+
+    /** CI sideload releases only — not drafts, not F-Droid clean tags. */
+    private fun isCiSideloadRelease(release: GithubReleaseDto): Boolean {
+        if (release.draft) return false
+        if (!buildNumberRegex.containsMatchIn(release.tagName)) return false
+        return release.assets.any { it.name.endsWith(".apk", ignoreCase = true) }
     }
 }

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/dto/GithubDtos.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/dto/GithubDtos.kt
@@ -9,6 +9,8 @@ data class GithubReleaseDto(
     val name: String,
     val body: String?,
     @Json(name = "html_url") val htmlUrl: String,
+    val draft: Boolean = false,
+    val prerelease: Boolean = false,
     val assets: List<GithubAssetDto> = emptyList()
 )
 

--- a/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
@@ -149,6 +149,17 @@ class SettingsRepository(context: Context) {
         dataStore.edit { prefs -> prefs[KEY_LAST_HEARTBEAT_DAY] = utcDay }
     }
 
+    /**
+     * Last [BuildConfig.VERSION_CODE] seen on this install (device-local).
+     * Null until the first launch that records it — used to detect upgrades.
+     */
+    suspend fun lastKnownVersionCode(): Int? =
+        dataStore.data.first()[KEY_LAST_KNOWN_VERSION_CODE]
+
+    suspend fun setLastKnownVersionCode(versionCode: Int) {
+        dataStore.edit { prefs -> prefs[KEY_LAST_KNOWN_VERSION_CODE] = versionCode }
+    }
+
     /** Active model cooldowns (expired entries already pruned). Survives process death. */
     suspend fun modelCooldowns(): Map<String, Long> {
         val prefs = dataStore.data.first()
@@ -338,6 +349,7 @@ class SettingsRepository(context: Context) {
         val KEY_SUPPORT_ID = stringPreferencesKey("support_id")
         val KEY_CRASH_REPORTING = booleanPreferencesKey("crash_reporting_enabled")
         val KEY_LAST_HEARTBEAT_DAY = stringPreferencesKey("sentry_last_heartbeat_utc_day")
+        val KEY_LAST_KNOWN_VERSION_CODE = intPreferencesKey("last_known_version_code")
         val KEY_EASTER_EGG = booleanPreferencesKey("easter_egg_discovered")
         val KEY_MODEL_COOLDOWNS = stringPreferencesKey("ai_model_cooldowns")
         val KEY_DAILY_LOG_REMINDER = booleanPreferencesKey("daily_log_reminder_enabled")

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/AnalyticsScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/AnalyticsScreen.kt
@@ -10,19 +10,23 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.AutoAwesome
 import com.anant.fitbuddy.ui.components.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -30,13 +34,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import com.anant.fitbuddy.ui.components.IconButton
 import androidx.compose.material3.MaterialTheme
-import com.anant.fitbuddy.ui.components.OutlinedButton
 import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
+import com.anant.fitbuddy.ui.components.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -47,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.anant.fitbuddy.data.database.BodyMeasurement
@@ -67,6 +72,9 @@ import kotlinx.coroutines.launch
 private val ProteinColor = MacroProteinColor
 private val CarbsColor = MacroCarbsColor
 private val FatsColor = MacroFatsColor
+
+/** Body composition charts always use this many newest readings (not week/month range). */
+private const val BODY_COMPOSITION_READING_LIMIT = 15
 
 private data class BodyMetric(
     val label: String,
@@ -109,6 +117,7 @@ fun AnalyticsScreen(
     onShiftMonth: (Int) -> Unit,
     onRequestInsight: () -> Unit,
     onOpenChat: () -> Unit,
+    onDismissInsight: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     var selectedRange by remember { mutableIntStateOf(0) } // 0 = Weekly, 1 = Monthly
@@ -122,6 +131,14 @@ fun AnalyticsScreen(
         if (isCurrentMonth) "This month" else DateUtils.monthLabel(analyticsMonthYm)
     }
 
+    progressInsightState.summary?.let {
+        ProgressInsightDialog(
+            state = progressInsightState,
+            onOpenChat = onOpenChat,
+            onDismiss = onDismissInsight
+        )
+    }
+
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(16.dp),
@@ -131,8 +148,7 @@ fun AnalyticsScreen(
             InsightCard(
                 state = progressInsightState,
                 isAiConfigured = isAiConfigured,
-                onRequestInsight = onRequestInsight,
-                onOpenChat = onOpenChat
+                onRequestInsight = onRequestInsight
             )
         }
 
@@ -167,8 +183,6 @@ fun AnalyticsScreen(
             }
         }
 
-        item { BodyMetricCard(measurements = measurements) }
-
         item {
             ChartCard(title = "Net Calories vs Target") {
                 CustomLineChart(
@@ -181,6 +195,8 @@ fun AnalyticsScreen(
                 )
             }
         }
+
+        item { ExerciseCard(exerciseSummaries = exerciseSummaries) }
 
         item {
             ChartCard(title = "Macronutrient Trend") {
@@ -201,7 +217,8 @@ fun AnalyticsScreen(
             }
         }
 
-        item { ExerciseCard(exerciseSummaries = exerciseSummaries) }
+        // Independent of Weekly/Monthly: always the most recent scale readings.
+        item { BodyMetricCard(measurements = measurements) }
     }
 }
 
@@ -295,9 +312,11 @@ private fun BodyMetricCard(measurements: List<BodyMeasurement>) {
                 .height(320.dp)
         ) { page ->
             val metric = BODY_METRICS[page]
-            // Oldest-to-newest, dropping readings that don't have this metric set.
+            // Last 15 readings (newest-first from Room), then oldest→newest for the chart.
+            // Ignores the Weekly/Monthly toggle above.
             val points = remember(measurements, page) {
                 measurements
+                    .take(BODY_COMPOSITION_READING_LIMIT)
                     .asReversed()
                     .mapNotNull { m -> metric.extractor(m)?.let { m.dateString.substringAfter("-") to it } }
             }
@@ -315,7 +334,7 @@ private fun BodyMetricCard(measurements: List<BodyMeasurement>) {
                     if (points.size >= 2) {
                         val sign = if (delta > 0) "+" else ""
                         Text(
-                            text = "$sign${trim(delta)}${metric.unit} since first reading",
+                            text = "$sign${trim(delta)}${metric.unit} over last ${points.size} readings",
                             style = MaterialTheme.typography.bodySmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant
                         )
@@ -372,60 +391,15 @@ private fun SummaryStat(label: String, value: String) {
 private fun InsightCard(
     state: ProgressInsightUiState,
     isAiConfigured: Boolean,
-    onRequestInsight: () -> Unit,
-    onOpenChat: () -> Unit
+    onRequestInsight: () -> Unit
 ) {
-    val hasInsight = state.summary != null
-
     ChartCard(title = "AI Progress Coach") {
-        if (hasInsight) {
-            state.bodyScore?.let { score ->
-                BodyScoreGauge(score)
-                Spacer(Modifier.height(12.dp))
-            }
-            Text(state.summary!!, style = MaterialTheme.typography.bodyMedium)
-            if (state.recommendations.isNotEmpty()) {
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    "Recommendations",
-                    style = MaterialTheme.typography.labelMedium,
-                    fontWeight = FontWeight.SemiBold
-                )
-                state.recommendations.forEach { rec ->
-                    Row(modifier = Modifier.fillMaxWidth().padding(top = 4.dp)) {
-                        Text("• ", style = MaterialTheme.typography.bodyMedium)
-                        Text(rec, style = MaterialTheme.typography.bodyMedium)
-                    }
-                }
-            }
-
-            Spacer(Modifier.height(12.dp))
-            OutlinedButton(
-                modifier = Modifier.fillMaxWidth(),
-                enabled = isAiConfigured && !state.isLoading && !state.isChatLoading,
-                onClick = onOpenChat
-            ) {
-                Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
-                Spacer(Modifier.size(8.dp))
-                Text(
-                    if (state.chatMessages.size > 1) "Continue conversation" else "Ask follow-up questions"
-                )
-            }
-            Text(
-                "Opens a dedicated chat — only a summary is sent for insights; full data is used when you ask questions.",
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.padding(top = 6.dp)
-            )
-            Spacer(Modifier.height(12.dp))
-        } else {
-            Text(
-                "Generate an insight from your charts, then ask follow-up questions in a dedicated chat.",
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            Spacer(Modifier.height(12.dp))
-        }
+        Text(
+            "Generate an insight from your charts, then ask follow-up questions in a dedicated chat.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(Modifier.height(12.dp))
 
         state.error?.let {
             Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
@@ -443,13 +417,7 @@ private fun InsightCard(
                 Icon(Icons.Filled.AutoAwesome, contentDescription = null)
             }
             Spacer(Modifier.size(8.dp))
-            Text(
-                when {
-                    state.isLoading -> "Analysing…"
-                    hasInsight -> "Refresh insight"
-                    else -> "Generate insight"
-                }
-            )
+            Text(if (state.isLoading) "Analysing…" else "Generate insight")
         }
         if (!isAiConfigured) {
             Spacer(Modifier.height(4.dp))
@@ -460,6 +428,58 @@ private fun InsightCard(
             )
         }
     }
+}
+
+@Composable
+private fun ProgressInsightDialog(
+    state: ProgressInsightUiState,
+    onOpenChat: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    val maxBodyHeight = (LocalConfiguration.current.screenHeightDp * 0.55f).dp
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
+        title = { Text("Progress insight") },
+        text = {
+            Column(
+                modifier = Modifier
+                    .heightIn(max = maxBodyHeight)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                state.bodyScore?.let { BodyScoreGauge(it) }
+                Text(state.summary.orEmpty(), style = MaterialTheme.typography.bodyMedium)
+                if (state.recommendations.isNotEmpty()) {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text(
+                            "Recommendations",
+                            style = MaterialTheme.typography.labelMedium,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        state.recommendations.forEach { rec ->
+                            Row(modifier = Modifier.fillMaxWidth()) {
+                                Text("• ", style = MaterialTheme.typography.bodyMedium)
+                                Text(rec, style = MaterialTheme.typography.bodyMedium)
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onOpenChat) {
+                Icon(Icons.AutoMirrored.Filled.Chat, contentDescription = null)
+                Spacer(Modifier.size(8.dp))
+                Text(
+                    if (state.chatMessages.size > 1) "Continue chat" else "Ask follow-up"
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Close") }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
@@ -549,7 +549,8 @@ fun MainScreen(
                                 isAiConfigured = isAiOnline,
                                 onShiftMonth = viewModel::shiftAnalyticsMonth,
                                 onRequestInsight = viewModel::requestProgressInsight,
-                                onOpenChat = { showProgressChat = true }
+                                onOpenChat = { showProgressChat = true },
+                                onDismissInsight = viewModel::dismissProgressInsight
                             )
 
                             Tab.BODY -> BodyScreen(

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -34,6 +34,7 @@ import com.anant.fitbuddy.data.model.TargetPlanResponse
 import com.anant.fitbuddy.data.model.WorkoutDraft
 import com.anant.fitbuddy.crash.CrashReporter
 import com.anant.fitbuddy.crash.HeartbeatInfo
+import com.anant.fitbuddy.crash.HeartbeatKind
 import com.anant.fitbuddy.data.remote.UpdateChecker
 import com.anant.fitbuddy.data.remote.UpdateCheckResult
 import com.anant.fitbuddy.data.remote.oauth.OpenRouterOAuth
@@ -636,8 +637,9 @@ class MainViewModel(
             username = s.usernameForHeartbeat
         )
         val today = java.time.LocalDate.now(java.time.ZoneOffset.UTC).toString()
+        val kind = if (force) HeartbeatKind.CONFETTI else HeartbeatKind.DAILY
         val sent = withContext(Dispatchers.IO) {
-            CrashReporter.sendDailyHeartbeat(info, force = force)
+            CrashReporter.sendHeartbeat(info, kind)
         }
         if (sent) {
             settingsRepository.markHeartbeatSent(today)

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -1398,7 +1398,7 @@ class MainViewModel(
                 }
                 .onFailure { e ->
                     _progressInsight.update {
-                        it.copy(isLoading = false, error = e.message ?: "Couldn't generate insight")
+                        it.copy(isLoading = false, error = friendlyThrowableMessage(e, "Couldn't generate insight"))
                     }
                 }
         }
@@ -1439,7 +1439,7 @@ class MainViewModel(
                     _progressInsight.update {
                         it.copy(
                             isChatLoading = false,
-                            error = e.message ?: "Couldn't get a reply"
+                            error = friendlyThrowableMessage(e, "Couldn't get a reply")
                         )
                     }
                 }
@@ -1458,6 +1458,11 @@ class MainViewModel(
         }
     }
 
+    /** Dismisses the insight popup and clears coach state (does not persist on the Progress card). */
+    fun dismissProgressInsight() {
+        _progressInsight.value = ProgressInsightUiState()
+    }
+
     private fun formatProgressInsightForChat(response: ProgressInsightResponse): String = buildString {
         append(response.summary)
         response.bodyScore?.let { append("\n\nBody score: $it/100") }
@@ -1465,6 +1470,15 @@ class MainViewModel(
             append("\n\nRecommendations:")
             response.recommendations.forEach { append("\n• $it") }
         }
+    }
+
+    /** Prefer [Throwable.message]; fall back to class name so blank Errors aren't a dead-end UI string. */
+    private fun friendlyThrowableMessage(e: Throwable, fallback: String): String {
+        val primary = e.message?.takeIf { it.isNotBlank() }
+            ?: e.cause?.message?.takeIf { it.isNotBlank() }
+        if (primary != null) return primary
+        val name = e::class.simpleName?.takeIf { it.isNotBlank() }
+        return if (name != null) "$fallback ($name)" else fallback
     }
 
     // --- Backup (export / import) -----------------------------------------------------------

--- a/app/src/test/java/com/anant/fitbuddy/data/model/ProgressInsightNormalizeTest.kt
+++ b/app/src/test/java/com/anant/fitbuddy/data/model/ProgressInsightNormalizeTest.kt
@@ -1,0 +1,103 @@
+package com.anant.fitbuddy.data.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class ProgressInsightNormalizeTest {
+
+    @Test
+    fun leavesCleanResponseAlone() {
+        val input = ProgressInsightResponse(
+            summary = "You're on track.",
+            recommendations = listOf("Keep logging meals.", "Train 3x/week."),
+            bodyScore = 72
+        )
+        assertEquals(input, input.normalized())
+    }
+
+    @Test
+    fun recoversPythonStyleRecommendationsEmbeddedInSummary() {
+        val mangled = ProgressInsightResponse(
+            summary = "Consistent daily logging is the immediate priority.','recommendations':[" +
+                "'Weigh yourself each morning.','Track every meal for 14 days.'," +
+                "'Start resistance training 3-4x/week.']",
+            recommendations = emptyList(),
+            bodyScore = null
+        )
+        val out = mangled.normalized()
+        assertEquals("Consistent daily logging is the immediate priority.", out.summary)
+        assertEquals(
+            listOf(
+                "Weigh yourself each morning.",
+                "Track every meal for 14 days.",
+                "Start resistance training 3-4x/week."
+            ),
+            out.recommendations
+        )
+        assertNull(out.bodyScore)
+    }
+
+    @Test
+    fun recoversSpacedPythonStyleEmbedFromNemotronSmash() {
+        val mangled = ProgressInsightResponse(
+            summary = "Exercise is inconsistent, with only 1–2 high-burn days per week and " +
+                "minimal activity otherwise.', 'recommendations': [" +
+                "'Raise protein to ~115 g/day.'," +
+                "'Eat closer to 2,000 kcal on training days.']",
+            recommendations = emptyList(),
+            bodyScore = null
+        )
+        val out = mangled.normalized()
+        assertEquals(
+            "Exercise is inconsistent, with only 1–2 high-burn days per week and " +
+                "minimal activity otherwise.",
+            out.summary
+        )
+        assertEquals(
+            listOf(
+                "Raise protein to ~115 g/day.",
+                "Eat closer to 2,000 kcal on training days."
+            ),
+            out.recommendations
+        )
+    }
+
+    @Test
+    fun recoversDoubleQuotedEmbedAndBodyScore() {
+        val mangled = ProgressInsightResponse(
+            summary = "Sparse data so far.\",\"recommendations\":[" +
+                "\"Log weight daily.\",\"Hit protein targets.\"],\"body_score\":null}",
+            recommendations = emptyList()
+        )
+        val out = mangled.normalized()
+        assertEquals("Sparse data so far.", out.summary)
+        assertEquals(listOf("Log weight daily.", "Hit protein targets."), out.recommendations)
+        assertNull(out.bodyScore)
+    }
+
+    @Test
+    fun recoversEmbeddedBodyScoreInt() {
+        val mangled = ProgressInsightResponse(
+            summary = "Good trend.','recommendations':['Add dal at lunch.'],'body_score':72}",
+            recommendations = emptyList()
+        )
+        val out = mangled.normalized()
+        assertEquals("Good trend.", out.summary)
+        assertEquals(listOf("Add dal at lunch."), out.recommendations)
+        assertEquals(72, out.bodyScore)
+    }
+
+    @Test
+    fun cleansTruncatedEmbedEvenWhenRecommendationsAlreadyPresent() {
+        val mangled = ProgressInsightResponse(
+            summary = "Solid recomposition trend.', 'recommendations': [",
+            recommendations = listOf("Raise protein to 115 g/day."),
+            bodyScore = 72
+        )
+        val out = mangled.normalized()
+        assertEquals("Solid recomposition trend.", out.summary)
+        assertEquals(listOf("Raise protein to 115 g/day."), out.recommendations)
+        assertEquals(72, out.bodyScore)
+    }
+}


### PR DESCRIPTION
## Summary
- Keep F-Droid clean-tag releases off GitHub Latest; in-app updater and site only follow CI `v*-buildN` releases
- Send a distinct Sentry **FitBuddy update heartbeat** after upgrades (independent of the daily pulse)
- Progress insights / Progress–Body ordering from develop since last main merge

## Test plan
- [ ] Release workflow publishes a new `v*-buildN` with `FitBuddy-latest.apk`
- [ ] `/releases/latest` stays on the CI release (not F-Droid)
- [ ] After installing the new build over an older one, Sentry shows update + daily heartbeats separately when both apply