### PR TITLE
fix(ci): target flavor-qualified Gradle tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,14 @@ jobs:
       - name: Create local.properties
         run: echo "sdk.dir=${ANDROID_HOME}" >> local.properties
 
-      - name: Compile debug
-        run: ./gradlew :app:compileDebugKotlin --no-daemon
+      - name: Compile debug (github)
+        run: ./gradlew :app:compileGithubDebugKotlin --no-daemon
 
-      - name: Compile release
-        run: ./gradlew :app:compileReleaseKotlin --no-daemon
+      - name: Compile release (github)
+        run: ./gradlew :app:compileGithubReleaseKotlin --no-daemon
 
-      - name: Unit tests
-        run: ./gradlew :app:testDebugUnitTest --no-daemon
+      - name: Compile debug (fdroid)
+        run: ./gradlew :app:compileFdroidDebugKotlin --no-daemon
+
+      - name: Unit tests (github)
+        run: ./gradlew :app:testGithubDebugUnitTest --no-daemon

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,9 +73,10 @@ jobs:
 
       - name: Build release APK
         # Sentry DSN and the cloud-backup API key are committed obfuscated in
-        # build.gradle.kts — no secrets needed here.
+        # build.gradle.kts — no secrets needed here. GitHub Releases ship the
+        # github flavor; F-Droid builds its own fdroid flavor from the fdroid branch.
         run: >
-          ./gradlew :app:assembleRelease :app:bundleRelease --no-daemon
+          ./gradlew :app:assembleGithubRelease :app:bundleGithubRelease --no-daemon
           -PappVersionCode=${{ steps.version.outputs.version_code }}
           -PappVersionName=${{ steps.version.outputs.version_name }}
 
@@ -83,8 +84,8 @@ jobs:
       # https://github.com/.../releases/latest/download/FitBuddy-latest.apk
       - name: Publish stable latest APK alias
         run: |
-          VERSIONED="app/build/outputs/apk/release/FitBuddy-${{ steps.version.outputs.version_name }}.apk"
-          cp "$VERSIONED" app/build/outputs/apk/release/FitBuddy-latest.apk
+          VERSIONED="app/build/outputs/apk/github/release/FitBuddy-${{ steps.version.outputs.version_name }}.apk"
+          cp "$VERSIONED" app/build/outputs/apk/github/release/FitBuddy-latest.apk
 
       - name: Prepare release notes
         id: notes
@@ -118,8 +119,8 @@ jobs:
           make_latest: true
           generate_release_notes: false
           files: |
-            app/build/outputs/apk/release/FitBuddy-${{ steps.version.outputs.version_name }}.apk
-            app/build/outputs/apk/release/FitBuddy-latest.apk
-            app/build/outputs/bundle/release/app-release.aab
+            app/build/outputs/apk/github/release/FitBuddy-${{ steps.version.outputs.version_name }}.apk
+            app/build/outputs/apk/github/release/FitBuddy-latest.apk
+            app/build/outputs/bundle/githubRelease/app-github-release.aab
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- PR #29's flavor split renamed Gradle tasks (compileDebugKotlin → compileGithubDebugKotlin, assembleRelease → assembleGithubRelease, etc.), which broke both CI and Release workflows on main ("Ambiguous matches").
- Points CI/Release at the github flavor explicitly, adds an fdroid debug compile sanity check to CI, and fixes release artifact output paths for the new flavor-qualified output dirs.

## Test plan
- [ ] CI run on this PR passes
- [ ] Release workflow succeeds on merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)