### PR TITLE
fix: request camera permission only when triggered

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/MainActivity.kt
+++ b/app/src/main/java/com/anant/fitbuddy/MainActivity.kt
@@ -74,28 +74,11 @@ class MainActivity : ComponentActivity() {
                     }
 
                     val onStartupPermissionsDenied: (List<String>) -> Unit = { denied ->
-                        val cameraDenied = Manifest.permission.CAMERA in denied
                         val notificationsDenied =
                             Manifest.permission.POST_NOTIFICATIONS in denied
                         if (notificationsDenied) {
                             viewModel.disableDailyLogReminder()
-                        }
-                        when {
-                            cameraDenied && notificationsDenied -> {
-                                viewModel.showTransientMessage(
-                                    "Camera and notifications not allowed."
-                                )
-                            }
-                            notificationsDenied -> {
-                                viewModel.showTransientMessage(
-                                    "Notifications not allowed."
-                                )
-                            }
-                            cameraDenied -> {
-                                viewModel.showTransientMessage(
-                                    "Camera permission not allowed."
-                                )
-                            }
+                            viewModel.showTransientMessage("Notifications not allowed.")
                         }
                     }
 

--- a/app/src/main/java/com/anant/fitbuddy/ui/StartupPermissions.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/StartupPermissions.kt
@@ -15,8 +15,10 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.ContextCompat
 
 /**
- * Requests runtime permissions needed for core FitBuddy features (camera + notifications)
+ * Requests runtime permissions needed at startup (notifications for daily reminders)
  * once when the UI first becomes ready after cold start.
+ *
+ * Camera permission is requested on-demand when the user triggers the camera.
  *
  * [onDenied] receives permission names that the user rejected (or previously denied).
  */
@@ -37,7 +39,6 @@ fun RequestStartupPermissions(
     LaunchedEffect(Unit) {
         if (launched) return@LaunchedEffect
         val needed = buildList {
-            add(Manifest.permission.CAMERA)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 add(Manifest.permission.POST_NOTIFICATIONS)
             }


### PR DESCRIPTION
Camera permission is now requested on-demand when the user taps the camera button, not at app startup.

## Changes
- Removed CAMERA from `StartupPermissions.kt` startup batch request
- Simplified `onStartupPermissionsDenied` callback (notifications only)
- Camera permission still handled via `rememberPermissionState` in `MainScreen.kt` when user triggers photo capture

## What was tested
- `compileGithubDebugKotlin` passes
- On-demand permission flow in `MainScreen.kt` unchanged (already worked this way)