### PR TITLE
feat: smarter AI target recommendations

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/data/model/AiPlanningModels.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/model/AiPlanningModels.kt
@@ -14,7 +14,8 @@ data class TargetPlanResponse(
     @Json(name = "target_protein_g") val targetProteinG: Int,
     @Json(name = "target_carbs_g") val targetCarbsG: Int,
     @Json(name = "target_fats_g") val targetFatsG: Int,
-    @Json(name = "rationale") val rationale: String
+    @Json(name = "rationale") val rationale: String,
+    @Json(name = "targets_changed") val targetsChanged: Boolean = true
 )
 
 /**

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
@@ -731,7 +731,23 @@ class RemoteAiDataSource(
     private fun buildTargetPrompt(contextJson: String): String = """
         You are FitBuddy, a nutrition and body-composition coach optimised for North Indian
         diets and lifestyles. Using the user's profile and latest body-composition data below,
-        decide the single most appropriate goal and design a daily nutrition plan for it.
+        first review the current readings and existing targets. Decide whether new targets are
+        actually needed, then respond accordingly.
+
+        STABILITY RULE — current targets awareness:
+        The user data includes "current_target_calories", "current_target_protein_g",
+        "current_target_carbs_g", and "current_target_fats_g". These are the targets the user
+        is currently following. Before suggesting new targets:
+        1. Review the user's current readings, body composition trends, and existing targets.
+        2. Decide whether the current targets are still appropriate for the user's goal and data.
+        3. If the current targets are already well-suited, set "targets_changed" to false, keep
+           all target values identical to the current ones, and write in "rationale" a short
+           encouraging message explaining that the user is on the right track and doesn't need
+           new calorie targets right now.
+        4. If new targets are warranted, set "targets_changed" to true, provide the new values,
+           and in "rationale" clearly justify WHY you are changing the targets — explain what
+           in the user's data or situation makes the current targets no longer appropriate
+           (e.g. weight change, body comp shift, goal mismatch, macro imbalance).
 
         Choose "recommended_goal" as EXACTLY one of:
         - "LOSE_WEIGHT": high body fat / cutting is the priority.
@@ -761,7 +777,7 @@ class RemoteAiDataSource(
         FEMALE with LOSE_WEIGHT needs a lower calorie budget and about 1 g/kg protein — do NOT
         assign young-male bodybuilding macros just because "protein is good".
 
-        Design realistic daily targets:
+        Design realistic daily targets (when targets_changed is true; otherwise echo current values):
         - Calories: sex-specific BMR (prefer measured bmr from latest_measurement; else
           Mifflin–St Jeor using age, sex, height_cm, current_weight_kg). Scale by activity_level
           to a rest-day TDEE. Then adjust for the goal with modest, sustainable deltas:
@@ -786,8 +802,11 @@ class RemoteAiDataSource(
           (protein/carbs 4 kcal/g, fats 9 kcal/g). Keep splits practical for North Indian meals
           (roti/dal/sabzi, dal-chawal, paratha, paneer/chole/rajma — not Western templates).
           Round to whole grams.
-        - "rationale": 2–4 sentences citing age, sex, weight/height, goal, and any used
-          body-comp metrics (bf%, muscle, BMR/BMI), plus the protein g/kg you applied.
+        - "rationale": 2–4 sentences. If targets_changed is true, clearly explain WHY the
+          targets are being changed — what in the user's data or situation makes the current
+          targets no longer appropriate, plus cite age, sex, weight/height, goal, and any used
+          body-comp metrics. If targets_changed is false, write an encouraging message that
+          the user is on the right track and their current targets don't need adjustment.
 
         Respond with a SINGLE JSON object and nothing else (no markdown fences, no commentary),
         EXACTLY this schema:
@@ -797,7 +816,8 @@ class RemoteAiDataSource(
           "target_protein_g": Int,
           "target_carbs_g": Int,
           "target_fats_g": Int,
-          "rationale": "String"
+          "rationale": "String",
+          "targets_changed": Boolean
         }
 
         User data (JSON):

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/ProfileScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/ProfileScreen.kt
@@ -576,13 +576,15 @@ private fun TargetProposalDialog(
     AlertDialog(
         onDismissRequest = onDismiss,
         icon = { Icon(Icons.Filled.AutoAwesome, contentDescription = null) },
-        title = { Text("AI recommendation") },
+        title = { Text(if (plan.targetsChanged) "AI recommendation" else "You're on track") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Text("Suggested goal: $goalLabel", fontWeight = FontWeight.SemiBold)
-                Text("${plan.dailyTargetCalories} kcal / day")
-                Text("Protein ${plan.targetProteinG}g · Carbs ${plan.targetCarbsG}g · Fats ${plan.targetFatsG}g")
-                HorizontalDivider()
+                if (plan.targetsChanged) {
+                    Text("Suggested goal: $goalLabel", fontWeight = FontWeight.SemiBold)
+                    Text("${plan.dailyTargetCalories} kcal / day")
+                    Text("Protein ${plan.targetProteinG}g · Carbs ${plan.targetCarbsG}g · Fats ${plan.targetFatsG}g")
+                    HorizontalDivider()
+                }
                 Text(
                     plan.rationale,
                     style = MaterialTheme.typography.bodySmall,
@@ -590,8 +592,18 @@ private fun TargetProposalDialog(
                 )
             }
         },
-        confirmButton = { TextButton(onClick = onApply) { Text("Apply") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Discard") } }
+        confirmButton = {
+            if (plan.targetsChanged) {
+                TextButton(onClick = onApply) { Text("Apply") }
+            } else {
+                TextButton(onClick = onDismiss) { Text("OK") }
+            }
+        },
+        dismissButton = {
+            if (plan.targetsChanged) {
+                TextButton(onClick = onDismiss) { Text("Discard") }
+            }
+        }
     )
 }
 

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -2773,6 +2773,9 @@ class MainViewModel(
             put("avg_daily_calories_in_recent", avgIntake ?: JSONObject.NULL)
             put("avg_daily_calories_burned_recent", avgBurned ?: JSONObject.NULL)
             put("current_target_calories", dashboardState.value.targetCalories)
+            put("current_target_protein_g", dashboardState.value.targetProtein)
+            put("current_target_carbs_g", dashboardState.value.targetCarbs)
+            put("current_target_fats_g", dashboardState.value.targetFats)
         }.toString()
     }
 
@@ -2784,12 +2787,17 @@ class MainViewModel(
     private suspend fun buildProgressContext(): String {
         val profile = dashboardState.value.profile
         val today = _realToday.value.ifBlank { DateUtils.today() }
-        // Inclusive 30-day window ending today.
-        val detailCutoff = DateUtils.addDays(today, -(PROGRESS_DETAIL_DAYS - 1))
+        // Exclude today's (incomplete) data — insight considers readings till yesterday only.
+        val yesterday = DateUtils.addDays(today, -1)
+        // Inclusive 30-day window ending yesterday.
+        val detailCutoff = DateUtils.addDays(yesterday, -(PROGRESS_DETAIL_DAYS - 1))
 
         val allFood = repository.getAllFoodDailySummaries()
+            .filter { it.dateString <= yesterday }
         val allExercise = repository.getAllExerciseDailySummaries()
+            .filter { it.dateString <= yesterday }
         val allMeasurements = repository.getAllBodyMeasurementsOnce()
+            .filter { it.dateString <= yesterday }
 
         val burnedByDate = allExercise.associate { it.dateString to it.totalBurned }
 
@@ -2840,9 +2848,10 @@ class MainViewModel(
             put(
                 "metrics_granularity_note",
                 "nutrition_daily / exercise_daily / body_measurements cover the past " +
-                    "$PROGRESS_DETAIL_DAYS days in detail. nutrition_prior_months / " +
-                    "exercise_prior_months / body_prior_months summarise older history as " +
-                    "calendar-month averages (omit if empty)."
+                    "$PROGRESS_DETAIL_DAYS days up to yesterday (today's incomplete data " +
+                    "is excluded). nutrition_prior_months / exercise_prior_months / " +
+                    "body_prior_months summarise older history as calendar-month averages " +
+                    "(omit if empty)."
             )
             put("avg_daily_net_calories_recent", avgNet ?: JSONObject.NULL)
             put("avg_exercise_calorie_eat_back_ratio", eatBackRatio ?: JSONObject.NULL)


### PR DESCRIPTION
## Summary
- AI now reviews current targets and user readings before suggesting new calorie/macro targets
- If current targets are appropriate, shows an encouraging "on track" message instead of redundant new values
- When new targets are suggested, the rationale clearly justifies why the change is needed
- Passes full current targets (calories, protein, carbs, fats) to the AI for comparison
- Progress insight now excludes today's incomplete data (considers readings till yesterday only)

## Changes
- `AiPlanningModels.kt`: added `targets_changed` field to `TargetPlanResponse`
- `RemoteAiDataSource.kt`: updated prompt with stability-aware target evaluation logic
- `MainViewModel.kt`: passes current macro targets in context; insight excludes today's data
- `ProfileScreen.kt`: dialog adapts to show "You're on track" or new targets with justification