### PR TITLE
feat: log scanned foods without saving and manage the food library

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/database/AppDatabase.kt
@@ -21,7 +21,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         WorkoutSession::class,
         WorkoutExercise::class
     ],
-    version = 11,
+    version = 12,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -41,6 +41,37 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        /** Adds manual [sortOrder] for saved foods and meal presets. */
+        val MIGRATION_11_12 = migration(11, 12) { db ->
+            db.execSQL(
+                "ALTER TABLE saved_foods ADD COLUMN sortOrder INTEGER NOT NULL DEFAULT 0"
+            )
+            db.execSQL(
+                "ALTER TABLE meal_presets ADD COLUMN sortOrder INTEGER NOT NULL DEFAULT 0"
+            )
+            // Preserve previous name-ASC order as the initial manual order.
+            db.execSQL(
+                """
+                UPDATE saved_foods SET sortOrder = (
+                    SELECT COUNT(*) FROM saved_foods AS s2
+                    WHERE s2.name COLLATE NOCASE < saved_foods.name COLLATE NOCASE
+                       OR (s2.name COLLATE NOCASE = saved_foods.name COLLATE NOCASE
+                           AND s2.id < saved_foods.id)
+                )
+                """.trimIndent()
+            )
+            db.execSQL(
+                """
+                UPDATE meal_presets SET sortOrder = (
+                    SELECT COUNT(*) FROM meal_presets AS m2
+                    WHERE m2.name COLLATE NOCASE < meal_presets.name COLLATE NOCASE
+                       OR (m2.name COLLATE NOCASE = meal_presets.name COLLATE NOCASE
+                           AND m2.id < meal_presets.id)
+                )
+                """.trimIndent()
+            )
+        }
+
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = Room.databaseBuilder(
@@ -53,6 +84,7 @@ abstract class AppDatabase : RoomDatabase() {
                     // Version 11 is the first production-shipped schema; any upgrade from v11+
                     // must provide an explicit Migration object so user data is never silently
                     // wiped on an app update.
+                    .addMigrations(MIGRATION_11_12)
                     .fallbackToDestructiveMigrationFrom(dropAllTables = true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
                     .build()
                 INSTANCE = instance
@@ -67,11 +99,11 @@ abstract class AppDatabase : RoomDatabase() {
          *
          * Example — adding a nullable column to food_logs:
          *
-         *   val MIGRATION_11_12 = migration(11, 12) {
+         *   val MIGRATION_12_13 = migration(12, 13) {
          *       it.execSQL("ALTER TABLE food_logs ADD COLUMN notes TEXT")
          *   }
          *
-         * Then in getDatabase: .addMigrations(MIGRATION_11_12)
+         * Then in getDatabase: .addMigrations(MIGRATION_11_12, MIGRATION_12_13)
          */
         fun migration(from: Int, to: Int, block: (SupportSQLiteDatabase) -> Unit): Migration =
             object : Migration(from, to) {

--- a/app/src/main/java/com/anant/fitbuddy/data/database/Daos.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/database/Daos.kt
@@ -209,14 +209,17 @@ data class ExerciseDailySummary(
 
 @Dao
 interface SavedFoodDao {
-    @Query("SELECT * FROM saved_foods ORDER BY name COLLATE NOCASE ASC")
+    @Query("SELECT * FROM saved_foods ORDER BY sortOrder ASC, name COLLATE NOCASE ASC")
     fun getAll(): Flow<List<SavedFood>>
 
-    @Query("SELECT * FROM saved_foods ORDER BY name COLLATE NOCASE ASC")
+    @Query("SELECT * FROM saved_foods ORDER BY sortOrder ASC, name COLLATE NOCASE ASC")
     suspend fun getAllOnce(): List<SavedFood>
 
     @Query("SELECT * FROM saved_foods WHERE barcode = :barcode LIMIT 1")
     suspend fun findByBarcode(barcode: String): SavedFood?
+
+    @Query("SELECT COALESCE(MAX(sortOrder), -1) FROM saved_foods")
+    suspend fun maxSortOrder(): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(food: SavedFood)
@@ -233,11 +236,14 @@ interface SavedFoodDao {
 
 @Dao
 interface MealPresetDao {
-    @Query("SELECT * FROM meal_presets ORDER BY name COLLATE NOCASE ASC")
+    @Query("SELECT * FROM meal_presets ORDER BY sortOrder ASC, name COLLATE NOCASE ASC")
     fun getAll(): Flow<List<MealPreset>>
 
-    @Query("SELECT * FROM meal_presets ORDER BY name COLLATE NOCASE ASC")
+    @Query("SELECT * FROM meal_presets ORDER BY sortOrder ASC, name COLLATE NOCASE ASC")
     suspend fun getAllOnce(): List<MealPreset>
+
+    @Query("SELECT COALESCE(MAX(sortOrder), -1) FROM meal_presets")
+    suspend fun maxSortOrder(): Int
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(preset: MealPreset)

--- a/app/src/main/java/com/anant/fitbuddy/data/database/Entities.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/database/Entities.kt
@@ -99,7 +99,9 @@ data class SavedFood(
     val fatsG: Int,
     val createdAt: Long,
     val barcode: String? = null,
-    val ingredients: List<LoggedIngredient>? = null
+    val ingredients: List<LoggedIngredient>? = null,
+    /** Manual library order; lower values appear first. */
+    val sortOrder: Int = 0
 )
 
 /** A reusable meal template (multiple foods) for one-tap logging from the dashboard. */
@@ -113,7 +115,9 @@ data class MealPreset(
     val carbsG: Int,
     val fatsG: Int,
     val createdAt: Long,
-    val foods: List<com.anant.fitbuddy.data.model.PresetMealFood>? = null
+    val foods: List<com.anant.fitbuddy.data.model.PresetMealFood>? = null,
+    /** Manual library order; lower values appear first. */
+    val sortOrder: Int = 0
 )
 
 /** A user-added exercise saved for the workout picker after AI (or offline) normalisation. */

--- a/app/src/main/java/com/anant/fitbuddy/data/repository/FitnessRepository.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/repository/FitnessRepository.kt
@@ -1318,7 +1318,8 @@ class FitnessRepository(
                 carbsG = draft.totalCarbs,
                 fatsG = draft.totalFats,
                 createdAt = System.currentTimeMillis(),
-                ingredients = draft.ingredients.map { LoggedIngredient.fromIngredientDraft(it) }
+                ingredients = draft.ingredients.map { LoggedIngredient.fromIngredientDraft(it) },
+                sortOrder = savedFoodDao.maxSortOrder() + 1
             )
         )
     }
@@ -1333,7 +1334,8 @@ class FitnessRepository(
                 carbsG = draft.totalCarbs,
                 fatsG = draft.totalFats,
                 createdAt = System.currentTimeMillis(),
-                foods = draft.foods.map { it.toPresetMealFood() }
+                foods = draft.foods.map { it.toPresetMealFood() },
+                sortOrder = mealPresetDao.maxSortOrder() + 1
             )
         )
     }
@@ -1341,6 +1343,38 @@ class FitnessRepository(
     suspend fun deleteSavedFood(food: SavedFood) = savedFoodDao.delete(food)
 
     suspend fun deleteMealPreset(preset: MealPreset) = mealPresetDao.delete(preset)
+
+    /** Updates an existing saved food (same id), preserving [SavedFood.sortOrder] and barcode. */
+    suspend fun updateSavedFood(food: SavedFood) {
+        require(food.id > 0) { "Saved food id required for update" }
+        savedFoodDao.insert(food)
+    }
+
+    /** Moves [food] one step up or down in the library order. */
+    suspend fun moveSavedFood(food: SavedFood, direction: Int) {
+        val list = savedFoodDao.getAllOnce().toMutableList()
+        val index = list.indexOfFirst { it.id == food.id }
+        if (index < 0) return
+        val target = index + direction
+        if (target !in list.indices) return
+        val tmp = list[index]
+        list[index] = list[target]
+        list[target] = tmp
+        savedFoodDao.insertAll(list.mapIndexed { i, item -> item.copy(sortOrder = i) })
+    }
+
+    /** Moves [preset] one step up or down in the meal-preset order. */
+    suspend fun moveMealPreset(preset: MealPreset, direction: Int) {
+        val list = mealPresetDao.getAllOnce().toMutableList()
+        val index = list.indexOfFirst { it.id == preset.id }
+        if (index < 0) return
+        val target = index + direction
+        if (target !in list.indices) return
+        val tmp = list[index]
+        list[index] = list[target]
+        list[target] = tmp
+        mealPresetDao.insertAll(list.mapIndexed { i, item -> item.copy(sortOrder = i) })
+    }
 
     /** Looks up a packaged product by EAN/UPC barcode via Open Food Facts. */
     suspend fun lookupProductByBarcode(barcode: String): ScannedProduct {
@@ -1371,7 +1405,22 @@ class FitnessRepository(
                 fatsG = product.fatsG,
                 createdAt = System.currentTimeMillis(),
                 barcode = product.barcode,
-                ingredients = entry.ingredients.map { LoggedIngredient.fromIngredientDraft(it) }
+                ingredients = entry.ingredients.map { LoggedIngredient.fromIngredientDraft(it) },
+                sortOrder = savedFoodDao.maxSortOrder() + 1
+            )
+        )
+    }
+
+    /** Logs a scanned product to [timestamp]'s day without adding it to the food library. */
+    suspend fun logScannedProduct(
+        product: ScannedProduct,
+        timestamp: Long = System.currentTimeMillis()
+    ) {
+        saveMealDraft(
+            MealDraft(
+                name = product.name,
+                timestamp = timestamp,
+                foods = listOf(product.toFoodEntry())
             )
         )
     }

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/EditSavedFoodDialog.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/EditSavedFoodDialog.kt
@@ -1,0 +1,141 @@
+package com.anant.fitbuddy.ui.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.anant.fitbuddy.data.database.SavedFood
+import com.anant.fitbuddy.data.model.IngredientDraft
+import com.anant.fitbuddy.data.model.LoggedIngredient
+import com.anant.fitbuddy.ui.components.TextButton
+
+@Composable
+fun EditSavedFoodDialog(
+    food: SavedFood,
+    onSave: (SavedFood) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var name by remember(food.id) { mutableStateOf(food.name) }
+    var calories by remember(food.id) { mutableStateOf(food.calories.toString()) }
+    var protein by remember(food.id) { mutableStateOf(food.proteinG.toString()) }
+    var carbs by remember(food.id) { mutableStateOf(food.carbsG.toString()) }
+    var fats by remember(food.id) { mutableStateOf(food.fatsG.toString()) }
+
+    fun buildFood(): SavedFood? {
+        val cal = calories.toIntOrNull() ?: return null
+        val p = protein.toIntOrNull() ?: 0
+        val c = carbs.toIntOrNull() ?: 0
+        val f = fats.toIntOrNull() ?: 0
+        val trimmed = name.trim().ifBlank { food.name }
+        return food.copy(
+            name = trimmed,
+            calories = cal,
+            proteinG = p,
+            carbsG = c,
+            fatsG = f,
+            ingredients = syncIngredients(food.ingredients, trimmed, cal, p, c, f)
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Edit saved food") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                food.barcode?.let { Text("Barcode: $it") }
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("Name") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = calories,
+                    onValueChange = { calories = it.filter { ch -> ch.isDigit() }.take(5) },
+                    label = { Text("Calories") },
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Box(Modifier.weight(1f)) {
+                        MacroEditField("Protein", protein) { protein = it }
+                    }
+                    Box(Modifier.weight(1f)) {
+                        MacroEditField("Carbs", carbs) { carbs = it }
+                    }
+                    Box(Modifier.weight(1f)) {
+                        MacroEditField("Fats", fats) { fats = it }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                enabled = buildFood() != null,
+                onClick = { buildFood()?.let(onSave) }
+            ) { Text("Save") }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text("Cancel") }
+        }
+    )
+}
+
+@Composable
+private fun MacroEditField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit
+) {
+    OutlinedTextField(
+        value = value,
+        onValueChange = { onValueChange(it.filter { c -> c.isDigit() }.take(4)) },
+        label = { Text(label) },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+        modifier = Modifier.fillMaxWidth()
+    )
+}
+
+/**
+ * Keep a single synthetic ingredient aligned with totals; leave multi-ingredient lists untouched
+ * (totals still update on the parent [SavedFood]).
+ */
+private fun syncIngredients(
+    ingredients: List<LoggedIngredient>?,
+    foodName: String,
+    calories: Int,
+    protein: Int,
+    carbs: Int,
+    fats: Int
+): List<LoggedIngredient>? {
+    if (ingredients != null && ingredients.size > 1) return ingredients
+    val weight = ingredients?.singleOrNull()?.let { it.quantity * it.unitWeightG }?.coerceAtLeast(1) ?: 100
+    return listOf(
+        LoggedIngredient.fromIngredientDraft(
+            IngredientDraft.fromAbsolute(
+                name = foodName,
+                weightG = weight,
+                calories = calories,
+                protein = protein,
+                carbs = carbs,
+                fats = fats
+            )
+        )
+    )
+}

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
@@ -715,7 +715,8 @@ fun MainScreen(
         }
     }
 
-    if (hasSettingsSnapshot && !settings.hasUserName) {
+    // Debug onboarding skips the name step; don't block the dashboard with a name prompt.
+    if (hasSettingsSnapshot && !settings.hasUserName && !BuildConfig.DEBUG) {
         NamePromptDialog(onSave = viewModel::saveUserName)
     }
 
@@ -776,6 +777,7 @@ fun MainScreen(
                 showMealPresetSheet = false
             },
             onDelete = viewModel::deleteMealPreset,
+            onMove = viewModel::moveMealPreset,
             onDismiss = { showMealPresetSheet = false }
         )
     }
@@ -793,6 +795,8 @@ fun MainScreen(
                 showSavedFoodSheet = false
             },
             onDelete = viewModel::deleteSavedFood,
+            onEdit = viewModel::updateSavedFood,
+            onMove = viewModel::moveSavedFood,
             onDismiss = { showSavedFoodSheet = false }
         )
     }
@@ -802,6 +806,8 @@ fun MainScreen(
             foods = savedFoods,
             mode = SavedFoodSheetMode.MANAGE_LIBRARY,
             onDelete = viewModel::deleteSavedFood,
+            onEdit = viewModel::updateSavedFood,
+            onMove = viewModel::moveSavedFood,
             onDismiss = { showSavedFoodManageSheet = false }
         )
     }
@@ -879,10 +885,11 @@ fun MainScreen(
     }
 
     pendingProduct?.let { product ->
+        val isMealAdd = scanFlow == ScanFlow.ADD_TO_MEAL
         ScannedProductDialog(
             product = product,
             isSaving = false,
-            primaryLabel = if (scanFlow == ScanFlow.ADD_TO_MEAL) "Add to meal" else "Save food",
+            primaryLabel = if (isMealAdd) "Add to meal" else "Save food",
             onPrimary = { confirmed ->
                 when (scanFlow) {
                     ScanFlow.ADD_TO_MEAL -> mealItems.add(confirmed.toFoodEntry())
@@ -890,6 +897,16 @@ fun MainScreen(
                 }
                 pendingProduct = null
                 scanFlow = null
+            },
+            secondaryLabel = if (isMealAdd) null else "Log today",
+            onSecondary = if (isMealAdd) {
+                null
+            } else {
+                { confirmed ->
+                    viewModel.logScannedProduct(confirmed)
+                    pendingProduct = null
+                    scanFlow = null
+                }
             },
             onDismiss = {
                 pendingProduct = null
@@ -1440,7 +1457,8 @@ private fun dashboardGreeting(firstName: String): String {
         in 17..20 -> "Good evening"
         else -> "Good night"
     }
-    return "$period, $firstName"
+    val name = firstName.trim()
+    return if (name.isEmpty()) period else "$period, $name"
 }
 
 @Composable

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/MealPresetPickerSheet.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/MealPresetPickerSheet.kt
@@ -1,6 +1,5 @@
 package com.anant.fitbuddy.ui.screens
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,24 +9,31 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import com.anant.fitbuddy.ui.components.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.anant.fitbuddy.data.database.MealPreset
+import com.anant.fitbuddy.ui.components.IconButton
 import com.anant.fitbuddy.ui.components.pressable
 
 /** Bottom sheet listing saved meals; tap to quick-log the whole meal to the active day. */
@@ -37,8 +43,17 @@ fun MealPresetPickerSheet(
     presets: List<MealPreset>,
     onPick: (MealPreset) -> Unit,
     onDelete: (MealPreset) -> Unit,
+    onMove: (MealPreset, direction: Int) -> Unit = { _, _ -> },
     onDismiss: () -> Unit
 ) {
+    var query by remember { mutableStateOf("") }
+    val filtered = remember(query, presets) {
+        val q = query.trim()
+        if (q.isEmpty()) presets
+        else presets.filter { it.name.contains(q, ignoreCase = true) }
+    }
+    val canReorder = query.isBlank() && presets.size > 1
+
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp)) {
             Text(
@@ -47,27 +62,57 @@ fun MealPresetPickerSheet(
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
             )
             Text(
-                text = "Tap a meal to log it to the day you're viewing. Build a meal and choose Save as preset to add one here.",
+                text = "Tap a meal to log it to the day you're viewing. Use the arrows to rearrange. Build a meal and choose Save as preset to add one here.",
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
             )
 
-            if (presets.isEmpty()) {
-                Text(
-                    text = "No saved meals yet. Build a meal, then tap Save as preset on the review screen.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+            if (presets.isNotEmpty()) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    label = { Text("Search") },
+                    placeholder = { Text("Meal name") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp)
                 )
-            } else {
-                LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
-                    items(presets, key = { it.id }) { preset ->
-                        MealPresetRow(
-                            preset = preset,
-                            onPick = { onPick(preset) },
-                            onDelete = { onDelete(preset) }
-                        )
+            }
+
+            when {
+                presets.isEmpty() -> {
+                    Text(
+                        text = "No saved meals yet. Build a meal, then tap Save as preset on the review screen.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+                filtered.isEmpty() -> {
+                    Text(
+                        text = "No meals match \"$query\".",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                        itemsIndexed(filtered, key = { _, preset -> preset.id }) { _, preset ->
+                            val fullIndex =
+                                if (canReorder) presets.indexOfFirst { it.id == preset.id } else -1
+                            MealPresetRow(
+                                preset = preset,
+                                canMoveUp = canReorder && fullIndex > 0,
+                                canMoveDown = canReorder && fullIndex in 0 until presets.lastIndex,
+                                onPick = { onPick(preset) },
+                                onMoveUp = { onMove(preset, -1) },
+                                onMoveDown = { onMove(preset, 1) },
+                                onDelete = { onDelete(preset) }
+                            )
+                        }
                     }
                 }
             }
@@ -78,7 +123,11 @@ fun MealPresetPickerSheet(
 @Composable
 private fun MealPresetRow(
     preset: MealPreset,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
     onPick: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
     onDelete: () -> Unit
 ) {
     val foodCount = preset.foods?.size ?: 0
@@ -86,7 +135,7 @@ private fun MealPresetRow(
         modifier = Modifier
             .fillMaxWidth()
             .pressable(onClick = onPick)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Surface(
@@ -102,7 +151,7 @@ private fun MealPresetRow(
                 )
             }
         }
-        Spacer(Modifier.size(16.dp))
+        Spacer(Modifier.size(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = preset.name,
@@ -118,6 +167,24 @@ private fun MealPresetRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        if (canMoveUp || canMoveDown) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                IconButton(
+                    onClick = onMoveUp,
+                    enabled = canMoveUp,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(Icons.Filled.KeyboardArrowUp, contentDescription = "Move up")
+                }
+                IconButton(
+                    onClick = onMoveDown,
+                    enabled = canMoveDown,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "Move down")
+                }
+            }
         }
         IconButton(onClick = onDelete) {
             Icon(

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/OnboardingScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/OnboardingScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
+import com.anant.fitbuddy.BuildConfig
 import com.anant.fitbuddy.ui.components.Button
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
@@ -225,8 +226,10 @@ fun OnboardingScreen(
     var aiError by remember { mutableStateOf<String?>(null) }
 
     val openRouterOAuthConnected = openRouterOAuthKey.isNotBlank()
-    val stepOneValid = firstName.trim().isNotEmpty() &&
-        lastName.trim().isNotEmpty() &&
+    // Debug builds skip the name fields so local testing can move through setup faster.
+    val skipNameInOnboarding = BuildConfig.DEBUG
+    val stepOneValid = (skipNameInOnboarding ||
+        (firstName.trim().isNotEmpty() && lastName.trim().isNotEmpty())) &&
         (age.toIntOrNull() ?: 0) in 10..120 &&
         (height.toDoubleOrNull() ?: 0.0) in 50.0..280.0 &&
         (weight.toDoubleOrNull() ?: 0.0) in 20.0..400.0
@@ -667,8 +670,10 @@ fun OnboardingScreen(
                                 style = MaterialTheme.typography.titleMedium,
                                 fontWeight = FontWeight.SemiBold
                             )
-                            OnboardingTextField("First name", firstName) { firstName = it }
-                            OnboardingTextField("Last name", lastName) { lastName = it }
+                            if (!skipNameInOnboarding) {
+                                OnboardingTextField("First name", firstName) { firstName = it }
+                                OnboardingTextField("Last name", lastName) { lastName = it }
+                            }
                             OnboardingNumberField("Age", age) { age = it }
                             OnboardingNumberField("Height (cm)", height, decimal = true) { height = it }
                             OnboardingNumberField("Current weight (kg)", weight, decimal = true) {

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/SavedFoodPickerSheet.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/SavedFoodPickerSheet.kt
@@ -9,24 +9,32 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Restaurant
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import com.anant.fitbuddy.ui.components.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.anant.fitbuddy.data.database.SavedFood
+import com.anant.fitbuddy.ui.components.IconButton
 import com.anant.fitbuddy.ui.components.pressable
 
 enum class SavedFoodSheetMode { PICK_FOR_MEAL, LOG_TO_DAY, MANAGE_LIBRARY }
@@ -39,9 +47,21 @@ fun SavedFoodPickerSheet(
     mode: SavedFoodSheetMode = SavedFoodSheetMode.PICK_FOR_MEAL,
     onPick: (SavedFood) -> Unit = {},
     onDelete: (SavedFood) -> Unit,
+    onEdit: (SavedFood) -> Unit = {},
+    onMove: (SavedFood, direction: Int) -> Unit = { _, _ -> },
     onDismiss: () -> Unit
 ) {
+    var query by remember { mutableStateOf("") }
+    var editingFood by remember { mutableStateOf<SavedFood?>(null) }
     val pickEnabled = mode != SavedFoodSheetMode.MANAGE_LIBRARY
+    val manageActions = mode == SavedFoodSheetMode.MANAGE_LIBRARY
+    val filtered = remember(query, foods) {
+        val q = query.trim()
+        if (q.isEmpty()) foods
+        else foods.filter { it.name.contains(q, ignoreCase = true) }
+    }
+    val canReorder = manageActions && query.isBlank() && foods.size > 1
+
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(modifier = Modifier.fillMaxWidth().padding(bottom = 24.dp)) {
             Text(
@@ -56,33 +76,75 @@ fun SavedFoodPickerSheet(
                     SavedFoodSheetMode.LOG_TO_DAY ->
                         "Tap a food to log it to the day you're viewing."
                     SavedFoodSheetMode.MANAGE_LIBRARY ->
-                        "Foods you scan or save as preset for reuse when logging or building meals."
+                        "Edit, reorder, or delete foods you scan or save as preset."
                 },
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier.padding(horizontal = 24.dp, vertical = 4.dp)
             )
 
-            if (foods.isEmpty()) {
-                Text(
-                    text = "No saved foods yet. Scan a barcode on the Body tab, or save a food as preset after AI review.",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+            if (foods.isNotEmpty()) {
+                OutlinedTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    label = { Text("Search") },
+                    placeholder = { Text("Food name") },
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp, vertical = 8.dp)
                 )
-            } else {
-                LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
-                    items(foods, key = { it.id }) { food ->
-                        SavedFoodRow(
-                            food = food,
-                            pickEnabled = pickEnabled,
-                            onPick = { onPick(food) },
-                            onDelete = { onDelete(food) }
-                        )
+            }
+
+            when {
+                foods.isEmpty() -> {
+                    Text(
+                        text = "No saved foods yet. Scan a barcode on the Body tab, or save a food as preset after AI review.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+                filtered.isEmpty() -> {
+                    Text(
+                        text = "No foods match \"$query\".",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(horizontal = 24.dp, vertical = 12.dp)
+                    )
+                }
+                else -> {
+                    LazyColumn(modifier = Modifier.heightIn(max = 420.dp)) {
+                        itemsIndexed(filtered, key = { _, food -> food.id }) { _, food ->
+                            val fullIndex = if (canReorder) foods.indexOfFirst { it.id == food.id } else -1
+                            SavedFoodRow(
+                                food = food,
+                                pickEnabled = pickEnabled,
+                                showEdit = manageActions,
+                                canMoveUp = canReorder && fullIndex > 0,
+                                canMoveDown = canReorder && fullIndex in 0 until foods.lastIndex,
+                                onPick = { onPick(food) },
+                                onEdit = { editingFood = food },
+                                onMoveUp = { onMove(food, -1) },
+                                onMoveDown = { onMove(food, 1) },
+                                onDelete = { onDelete(food) }
+                            )
+                        }
                     }
                 }
             }
         }
+    }
+
+    editingFood?.let { food ->
+        EditSavedFoodDialog(
+            food = food,
+            onSave = {
+                onEdit(it)
+                editingFood = null
+            },
+            onDismiss = { editingFood = null }
+        )
     }
 }
 
@@ -90,14 +152,20 @@ fun SavedFoodPickerSheet(
 private fun SavedFoodRow(
     food: SavedFood,
     pickEnabled: Boolean,
+    showEdit: Boolean,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
     onPick: () -> Unit,
+    onEdit: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
     onDelete: () -> Unit
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .then(if (pickEnabled) Modifier.pressable(onClick = onPick) else Modifier)
-            .padding(horizontal = 24.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
         Surface(
@@ -113,7 +181,7 @@ private fun SavedFoodRow(
                 )
             }
         }
-        Spacer(Modifier.size(16.dp))
+        Spacer(Modifier.size(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
                 text = food.name,
@@ -125,6 +193,32 @@ private fun SavedFoodRow(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+        }
+        if (canMoveUp || canMoveDown) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                IconButton(
+                    onClick = onMoveUp,
+                    enabled = canMoveUp,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(Icons.Filled.KeyboardArrowUp, contentDescription = "Move up")
+                }
+                IconButton(
+                    onClick = onMoveDown,
+                    enabled = canMoveDown,
+                    modifier = Modifier.size(36.dp)
+                ) {
+                    Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "Move down")
+                }
+            }
+        }
+        if (showEdit) {
+            IconButton(onClick = onEdit) {
+                Icon(
+                    Icons.Filled.Edit,
+                    contentDescription = "Edit ${food.name}"
+                )
+            }
         }
         IconButton(onClick = onDelete) {
             Icon(

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -979,6 +979,32 @@ class MainViewModel(
         }
     }
 
+    fun updateSavedFood(food: SavedFood) {
+        viewModelScope.launch {
+            runCatching { repository.updateSavedFood(food) }
+                .onSuccess {
+                    _analysisState.update { it.copy(userMessage = "Updated \"${food.name}\"") }
+                }
+                .onFailure { e ->
+                    _analysisState.update {
+                        it.copy(userMessage = e.message ?: "Couldn't update food")
+                    }
+                }
+        }
+    }
+
+    fun moveSavedFood(food: SavedFood, direction: Int) {
+        viewModelScope.launch {
+            repository.moveSavedFood(food, direction)
+        }
+    }
+
+    fun moveMealPreset(preset: MealPreset, direction: Int) {
+        viewModelScope.launch {
+            repository.moveMealPreset(preset, direction)
+        }
+    }
+
     private val _barcodeLookupLoading = MutableStateFlow(false)
     val barcodeLookupLoading: StateFlow<Boolean> = _barcodeLookupLoading.asStateFlow()
 
@@ -1014,6 +1040,25 @@ class MainViewModel(
                 .onFailure { e ->
                     _analysisState.update {
                         it.copy(userMessage = e.message ?: "Couldn't save food")
+                    }
+                }
+        }
+    }
+
+    /** Logs a barcode product to the active day without saving it to the library. */
+    fun logScannedProduct(product: ScannedProduct) {
+        viewModelScope.launch {
+            runCatching {
+                repository.logScannedProduct(product, activeDayTimestamp())
+            }
+                .onSuccess {
+                    _analysisState.update {
+                        it.copy(userMessage = "Logged ${product.name} · ${product.calories} kcal")
+                    }
+                }
+                .onFailure { e ->
+                    _analysisState.update {
+                        it.copy(userMessage = e.message ?: "Couldn't log food")
                     }
                 }
         }

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -6,7 +6,8 @@ Features:
 • Smart logging — photo or text; AI parses food and exercise automatically
 • Meal review — edit dish name, adjust ingredient weights with live macro recalc
 • Editable workouts — structured sessions, AI session names, upgrade simple logs
-• Presets — bookmark meals for one-tap future logging
+• Presets — searchable saved foods and meals; edit foods, rearrange lists, one-tap log
+• Barcode scan — look up packaged foods; save to library or log straight to today
 • Dashboard — daily calorie ring, combined food/exercise log, macro breakdown
 • Analytics — custom charts; rolling 30-day progress window
 • Encrypted backups — AES-256-GCM; gzip; optional cloud with append-only chunks


### PR DESCRIPTION
## Summary
- Barcode scan from Body can **Log today** without adding the product to the saved-food library (Save food still available).
- Saved foods and meals sheets gain **search**, and lists can be **reordered** manually (persisted `sortOrder`, Room migration 11→12).
- Manage library can **edit** saved food name/macros.

## Test plan
- [x] Body → Scan barcode → confirm **Log today** logs to the active day and does not create a library entry
- [x] Same flow → **Save food** still adds to the library
- [x] Body → Manage → search filters foods; edit updates name/macros; up/down reorder persists after reopen
- [x] Log hub → Saved meals → search and reorder work; tap still logs the meal
- [x] Upgrade from a v11 install: library and logs still present after update (no wipe)