### PR TITLE
fix: avoid crash when no camera app is installed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
+    <!-- CAMERA permission would otherwise imply camera is required for Play filtering. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+
     <!-- Android 11+ package visibility: Custom Tabs + FreeScale measurement bridge. -->
     <queries>
         <intent>
@@ -18,6 +22,10 @@
             <action android:name="android.intent.action.VIEW" />
             <category android:name="android.intent.category.BROWSABLE" />
             <data android:scheme="https" />
+        </intent>
+        <!-- Needed so resolveActivity can see camera apps before TakePicturePreview. -->
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
         </intent>
         <package android:name="com.anant.freescale" />
         <package android:name="com.anant.freescale.debug" />

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
@@ -1,8 +1,10 @@
 package com.anant.fitbuddy.ui.screens
 
 import android.Manifest
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.provider.MediaStore
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -272,12 +274,27 @@ fun MainScreen(
         }
     }
 
+    // Some devices (custom ROMs, no camera app) throw ActivityNotFoundException on
+    // IMAGE_CAPTURE. Resolve first; catch as a last resort so the app never crashes.
+    fun launchCameraPreview() {
+        val capture = Intent(MediaStore.ACTION_IMAGE_CAPTURE)
+        if (capture.resolveActivity(context.packageManager) == null) {
+            SystemToast.show(context, "No camera app available. Use Gallery instead.")
+            return
+        }
+        try {
+            cameraLauncher.launch(null)
+        } catch (_: ActivityNotFoundException) {
+            SystemToast.show(context, "No camera app available. Use Gallery instead.")
+        }
+    }
+
     // TakePicturePreview starts IMAGE_CAPTURE, which requires CAMERA at runtime on
     // Android 6+. Launching without it crashes with SecurityException (permission denial).
     val cameraPermission = rememberPermissionState(Manifest.permission.CAMERA) { granted ->
         if (granted) {
             viewModel.notifyExternalMediaLaunch()
-            cameraLauncher.launch(null)
+            launchCameraPreview()
         } else {
             SystemToast.show(context, "Camera permission not allowed.")
         }
@@ -667,7 +684,7 @@ fun MainScreen(
                 showLogHub = false
                 viewModel.notifyExternalMediaLaunch()
                 if (cameraPermission.status.isGranted) {
-                    cameraLauncher.launch(null)
+                    launchCameraPreview()
                 } else {
                     cameraPermission.launchPermissionRequest()
                 }


### PR DESCRIPTION
## Summary
- Guard photo logging against devices with no `IMAGE_CAPTURE` handler (Sentry: `ActivityNotFoundException` on custom ROMs).
- Declare camera as optional and add package-visibility query so resolve works on Android 11+.

## Test plan
- [ ] On a normal device: Photo → camera opens, meal analysis works
- [ ] Deny camera permission: toast, no crash
- [ ] (If possible) device/emulator without a camera app: toast “No camera app available…”, app stays up