### PR TITLE
fix: persist OpenAI to OpenAI-compatible migration on upgrade

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
+++ b/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
@@ -83,6 +83,8 @@ class FitBuddyApp : Application() {
         super.onCreate()
         val settings = runBlocking {
             settingsRepository.ensureSupportId()
+            // Fold legacy dedicated OpenAI → OpenAI-compatible before anything reads settings.
+            settingsRepository.persistLegacyOpenAiMigrationIfNeeded()
             settingsRepository.settings.first()
         }
         CrashReporter.init(

--- a/app/src/main/java/com/anant/fitbuddy/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/settings/AppSettings.kt
@@ -461,15 +461,18 @@ data class AppSettings(
     /**
      * Legacy installs used a dedicated OpenAI provider. Fold them into [AiProvider.CUSTOM]
      * with the official OpenAI base URL so Settings only shows one OpenAI-compatible option.
+     * Keys, photo/text models, Auto failover, and active-model markers are preserved.
      */
     fun migratedFromLegacyOpenAiProvider(): AppSettings {
         if (provider != AiProvider.OPENAI) return this
         val keys = keysFor(AiProvider.OPENAI).ifEmpty { customApiKeys }
+        val photo = customModel.ifBlank { openAiModel.ifBlank { DEFAULT_CUSTOM_MODEL } }
+        val text = customTextModel.ifBlank { openAiTextModel }
         return copy(
             provider = AiProvider.CUSTOM,
             customBaseUrl = customBaseUrl.ifBlank { DEFAULT_CUSTOM_BASE_URL },
-            customModel = customModel.ifBlank { openAiModel.ifBlank { DEFAULT_CUSTOM_MODEL } },
-            customTextModel = customTextModel.ifBlank { openAiTextModel },
+            customModel = photo,
+            customTextModel = text,
             customApiKeys = keys,
             customApiKey = keys.firstOrNull().orEmpty(),
             aiAutoFailoverByProvider = aiAutoFailoverByProvider +
@@ -480,7 +483,10 @@ data class AppSettings(
                 AiProvider.CUSTOM
             } else {
                 activeAiProvider
-            }
+            },
+            // Prefer already-migrated active ids; otherwise keep the OpenAI selections.
+            activePhotoModel = activePhotoModel.ifBlank { photo },
+            activeTextModel = activeTextModel.ifBlank { text.ifBlank { photo } }
         )
     }
 

--- a/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
@@ -182,6 +182,17 @@ class SettingsRepository(context: Context) {
         ).migratedFromLegacyOpenAiProvider()
     }
 
+    /**
+     * One-shot DataStore rewrite: if the removed [AiProvider.OPENAI] is still stored,
+     * persist the in-memory [AppSettings.migratedFromLegacyOpenAiProvider] result so keys,
+     * models, and provider survive without the user opening Settings → Save.
+     */
+    suspend fun persistLegacyOpenAiMigrationIfNeeded() {
+        val rawProvider = dataStore.data.first()[KEY_PROVIDER] ?: return
+        if (rawProvider != AiProvider.OPENAI.name) return
+        save(settings.first())
+    }
+
     /** Ensures a stable anonymous support id exists; returns it. */
     suspend fun ensureSupportId(): String {
         val existing = dataStore.data.first()[KEY_SUPPORT_ID].orEmpty()

--- a/app/src/test/java/com/anant/fitbuddy/data/settings/AppSettingsTest.kt
+++ b/app/src/test/java/com/anant/fitbuddy/data/settings/AppSettingsTest.kt
@@ -60,6 +60,42 @@ class AppSettingsTest {
     }
 
     @Test
+    fun `legacy OpenAI provider migrates to OpenAI-compatible with keys and models`() {
+        val legacy = AppSettings(
+            provider = AiProvider.OPENAI,
+            openAiApiKeys = listOf("sk-legacy", "sk-2"),
+            openAiApiKey = "sk-legacy",
+            openAiModel = "gpt-4o",
+            openAiTextModel = "gpt-4o-mini",
+            aiAutoFailoverByProvider = mapOf(AiProvider.OPENAI to false),
+            activeAiProvider = AiProvider.OPENAI,
+            activePhotoModel = "gpt-4o",
+            activeTextModel = "gpt-4o-mini"
+        )
+        val migrated = legacy.migratedFromLegacyOpenAiProvider()
+        assertEquals(AiProvider.CUSTOM, migrated.provider)
+        assertEquals(AppSettings.DEFAULT_CUSTOM_BASE_URL, migrated.customBaseUrl)
+        assertEquals(listOf("sk-legacy", "sk-2"), migrated.customApiKeys)
+        assertEquals("sk-legacy", migrated.customApiKey)
+        assertEquals("gpt-4o", migrated.customModel)
+        assertEquals("gpt-4o-mini", migrated.customTextModel)
+        assertFalse(migrated.autoFailoverFor(AiProvider.CUSTOM))
+        assertTrue(migrated.showPaidFor(AiProvider.CUSTOM))
+        assertEquals(AiProvider.CUSTOM, migrated.activeAiProvider)
+        assertEquals("gpt-4o", migrated.activePhotoModel)
+        assertEquals("gpt-4o-mini", migrated.activeTextModel)
+        assertEquals("Bearer sk-legacy", migrated.authHeader)
+        assertTrue(migrated.chatUrl.startsWith("https://api.openai.com/"))
+        assertTrue(migrated.isConfigured)
+    }
+
+    @Test
+    fun `non-OpenAI provider is unchanged by OpenAI migration`() {
+        val settings = AppSettings(provider = AiProvider.GEMINI, geminiApiKey = "g")
+        assertEquals(settings, settings.migratedFromLegacyOpenAiProvider())
+    }
+
+    @Test
     fun `openrouter auth header only present when key set`() {
         val noKey = AppSettings(provider = AiProvider.OPENROUTER, openRouterApiKey = "")
         assertNull(noKey.authHeader)


### PR DESCRIPTION
## Summary
- On first launch after upgrade, rewrite stored `OPENAI` provider to OpenAI-compatible (keys, models, URL preserved) so migration does not depend on opening Settings → Save.
- Cover migration with unit tests.

## Test plan
- [ ] Fresh install on OpenAI-compatible still works
- [ ] Install with legacy `provider=OPENAI` in DataStore → upgrade → provider is OpenAI-compatible, same key/models, no re-entry