### PR TITLE
feat: add start/stop diagnostic log export in Settings

### DIFF
--- a/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
+++ b/app/src/main/java/com/anant/fitbuddy/FitBuddyApp.kt
@@ -17,6 +17,7 @@ import com.anant.fitbuddy.data.repository.FitnessRepository
 import com.anant.fitbuddy.data.settings.SettingsRepository
 import com.anant.fitbuddy.reminders.ReminderReceiver
 import com.anant.fitbuddy.reminders.ReminderScheduler
+import com.anant.fitbuddy.util.DiagnosticLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -92,6 +93,12 @@ class FitBuddyApp : Application() {
             enabled = settings.crashReportingEnabled,
             supportId = settings.supportId
         )
+        DiagnosticLogger.init(this)
+        DiagnosticLogger.setEnabled(
+            settings.diagnosticLoggingEnabled,
+            settings,
+            restartSession = false
+        )
         NetworkModule.setVerboseHttpLogging(settings.verboseHttpLogging)
         ReminderReceiver.ensureChannel(this)
         ReminderScheduler.applyFromSettings(this, settings)
@@ -114,6 +121,20 @@ class FitBuddyApp : Application() {
                         ReminderScheduler.scheduleNext(this@FitBuddyApp, hour, minute)
                     } else {
                         ReminderScheduler.cancel(this@FitBuddyApp)
+                    }
+                }
+        }
+        appScope.launch {
+            settingsRepository.settings
+                .map { it.diagnosticLoggingEnabled }
+                .distinctUntilChanged()
+                .collect { enabled ->
+                    // User toggles restart via ViewModel; here only sync off / resume-on.
+                    if (!enabled) {
+                        DiagnosticLogger.setEnabled(false, restartSession = false)
+                    } else if (!DiagnosticLogger.isEnabled()) {
+                        val s = settingsRepository.settings.first()
+                        DiagnosticLogger.setEnabled(true, s, restartSession = false)
                     }
                 }
         }

--- a/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/remote/RemoteAiDataSource.kt
@@ -27,6 +27,7 @@ import com.anant.fitbuddy.data.remote.dto.ModelDto
 import com.anant.fitbuddy.data.remote.dto.ResponseFormat
 import com.anant.fitbuddy.data.settings.AiProvider
 import com.anant.fitbuddy.data.settings.AppSettings
+import com.anant.fitbuddy.util.DiagnosticLogger
 import com.anant.fitbuddy.data.settings.FailoverLadders
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonDataException
@@ -371,15 +372,34 @@ class RemoteAiDataSource(
                 return response
             } catch (e: HttpException) {
                 if (e.code() == 429 && attempt < MAX_RETRIES) {
+                    DiagnosticLogger.log(
+                        "http",
+                        "retry_429",
+                        mapOf("attempt" to attempt.toString(), "code" to "429")
+                    )
                     delay(backoffFor(e, attempt))
                     attempt++
                     continue
                 }
                 val friendly = friendlyHttpMessage(e)
+                DiagnosticLogger.log(
+                    "http",
+                    "error",
+                    mapOf(
+                        "code" to e.code().toString(),
+                        "message" to friendly
+                    )
+                )
                 if (e.code() == 400) throw AiBadRequestException(friendly, e)
                 throw IllegalStateException(friendly, e)
             } catch (e: IOException) {
-                throw IllegalStateException("Network error: ${e.message ?: "check your connection"}", e)
+                val msg = "Network error: ${e.message ?: "check your connection"}"
+                DiagnosticLogger.log(
+                    "http",
+                    "network_error",
+                    mapOf("message" to msg, "cause" to e.javaClass.simpleName)
+                )
+                throw IllegalStateException(msg, e)
             }
         }
     }

--- a/app/src/main/java/com/anant/fitbuddy/data/repository/FitnessRepository.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/repository/FitnessRepository.kt
@@ -82,6 +82,7 @@ import com.anant.fitbuddy.data.settings.AiProvider
 import com.anant.fitbuddy.data.settings.AppSettings
 import com.anant.fitbuddy.data.settings.FailoverLadders
 import com.anant.fitbuddy.util.DeviceIdentity
+import com.anant.fitbuddy.util.DiagnosticLogger
 import com.anant.fitbuddy.data.settings.ModelCooldown
 import com.anant.fitbuddy.data.settings.ModelCooldownPolicy
 import com.anant.fitbuddy.data.settings.SettingsRepository
@@ -1037,6 +1038,19 @@ class FitnessRepository(
     ): AnalysisOutcome {
         val settings = settingsRepository.settings.first()
         val forceOffline = settings.developerModeUnlocked && settings.forceOfflineAiSimulator
+        val modality = if (imageBytes != null) "photo" else "text"
+        DiagnosticLogger.log(
+            "analyze",
+            "start",
+            mapOf(
+                "modality" to modality,
+                "provider" to settings.provider.name,
+                "model" to settings.modelFor(imageBytes != null),
+                "host" to DiagnosticLogger.hostOf(settings.chatUrl),
+                "configured" to settings.isConfigured.toString(),
+                "force_offline" to forceOffline.toString()
+            )
+        )
 
         // Preferred provider configured: live AI with same-platform key/model failover.
         // Surface real failures instead of silently faking a result (silent offline fallback
@@ -1055,33 +1069,57 @@ class FitnessRepository(
                         active, userText, userStateContextJson, dataUrl, forceEstimate
                     )
                 }
-                processResponse(response, customTimestamp = customTimestamp, userText = userText)
+                val outcome = processResponse(response, customTimestamp = customTimestamp, userText = userText)
                     .withFailoverNote(failoverNote)
+                DiagnosticLogger.log(
+                    "analyze",
+                    "ok",
+                    mapOf(
+                        "modality" to modality,
+                        "status" to response.status,
+                        "failover" to (failoverNote ?: "none")
+                    )
+                )
+                outcome
             } catch (e: Exception) {
-                AnalysisOutcome.Error(formatAiConnectionError(e))
+                val message = formatAiConnectionError(e)
+                DiagnosticLogger.log(
+                    "analyze",
+                    "error",
+                    mapOf(
+                        "modality" to modality,
+                        "message" to message,
+                        "cause" to e.javaClass.simpleName
+                    )
+                )
+                AnalysisOutcome.Error(message)
             }
         }
 
         // Not configured / forced offline: the offline simulator cannot read images.
         if (imageBytes != null) {
-            return AnalysisOutcome.Error(
-                if (forceOffline) {
-                    "Force offline simulator can't analyse photos. Turn it off or use text."
-                } else {
-                    "Connect an AI provider in Settings to analyse food photos."
-                }
-            )
+            val message = if (forceOffline) {
+                "Force offline simulator can't analyse photos. Turn it off or use text."
+            } else {
+                "Connect an AI provider in Settings to analyse food photos."
+            }
+            DiagnosticLogger.log("analyze", "error", mapOf("modality" to modality, "message" to message))
+            return AnalysisOutcome.Error(message)
         }
 
         return try {
             val region = AppRegion.fromStored(settings.region) ?: AppRegion.INDIA
-            processResponse(
+            val outcome = processResponse(
                 simulateAIService(userText, inferMode(userText, false), region),
                 customTimestamp = customTimestamp,
                 userText = userText
             )
+            DiagnosticLogger.log("analyze", "ok", mapOf("modality" to modality, "mode" to "offline_sim"))
+            outcome
         } catch (e: Exception) {
-            AnalysisOutcome.Error(e.message ?: "Analysis failed")
+            val message = e.message ?: "Analysis failed"
+            DiagnosticLogger.log("analyze", "error", mapOf("modality" to modality, "message" to message))
+            AnalysisOutcome.Error(message)
         }
     }
 
@@ -2069,9 +2107,10 @@ class FitnessRepository(
         if (!settings.aiAutoFailover) {
             var lastError: Exception? = null
             for (key in keys) {
+                var activeModel = preferredSelected
                 try {
                     val attempt = settings.withKey(platform, key)
-                    val activeModel = attempt.modelFor(preferVisionModels)
+                    activeModel = attempt.modelFor(preferVisionModels)
                     onModelActive?.invoke(activeModel)
                     val result = block(attempt)
                     settingsRepository.setActiveAiModel(
@@ -2082,6 +2121,15 @@ class FitnessRepository(
                     return result to null
                 } catch (e: Exception) {
                     lastError = e
+                    DiagnosticLogger.log(
+                        "failover",
+                        "key_failed",
+                        mapOf(
+                            "model" to activeModel,
+                            "cause" to e.javaClass.simpleName,
+                            "message" to (e.message ?: "")
+                        )
+                    )
                 }
             }
             throw lastError ?: IllegalStateException("Couldn't connect to AI")
@@ -2123,6 +2171,16 @@ class FitnessRepository(
                     lastError = e
                     lastModelError = e
                     if (ModelCooldownPolicy.isRateLimitError(e)) rateLimitedOnModel = true
+                    DiagnosticLogger.log(
+                        "failover",
+                        "attempt_failed",
+                        mapOf(
+                            "model" to modelId,
+                            "rate_limited" to rateLimitedOnModel.toString(),
+                            "cause" to e.javaClass.simpleName,
+                            "message" to (e.message ?: "")
+                        )
+                    )
                 }
             }
             if (rateLimitedOnModel && lastModelError != null) {

--- a/app/src/main/java/com/anant/fitbuddy/data/settings/AppSettings.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/settings/AppSettings.kt
@@ -124,6 +124,11 @@ data class AppSettings(
     /** When false, Sentry does not send crash events (SDK may still be initialized). Off by default on F-Droid. */
     val crashReportingEnabled: Boolean = !BuildConfig.DEBUG && !BuildConfig.IS_FDROID,
     /**
+     * When true, AI connection steps are written to a local diagnostic log the user can export
+     * from Settings (no meals, photos, or API keys). Off by default.
+     */
+    val diagnosticLoggingEnabled: Boolean = false,
+    /**
      * Diet/region pack for AI prompts and offline staples: `INDIA`, `US`, or `EUROPE`.
      * Empty until the user finishes the region selection page (or restores a backup that has it).
      */

--- a/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
+++ b/app/src/main/java/com/anant/fitbuddy/data/settings/SettingsRepository.kt
@@ -150,6 +150,7 @@ class SettingsRepository(context: Context) {
             autoCheckUpdates = prefs[KEY_AUTO_CHECK_UPDATES] ?: (!BuildConfig.DEBUG && !BuildConfig.IS_FDROID),
             supportId = prefs[KEY_SUPPORT_ID].orEmpty(),
             crashReportingEnabled = prefs[KEY_CRASH_REPORTING] ?: (!BuildConfig.DEBUG && !BuildConfig.IS_FDROID),
+            diagnosticLoggingEnabled = prefs[KEY_DIAGNOSTIC_LOGGING] ?: false,
             region = prefs[KEY_REGION].orEmpty(),
             regionRequestSentAt = prefs[KEY_REGION_REQUEST_SENT_AT] ?: 0L,
             easterEggDiscovered = prefs[KEY_EASTER_EGG] ?: false,
@@ -322,6 +323,7 @@ class SettingsRepository(context: Context) {
                     settings.insightAnimationChoice != AppSettings.LOADING_ANIM_OFF
             prefs[KEY_AUTO_CHECK_UPDATES] = settings.autoCheckUpdates
             prefs[KEY_CRASH_REPORTING] = settings.crashReportingEnabled
+            prefs[KEY_DIAGNOSTIC_LOGGING] = settings.diagnosticLoggingEnabled
             prefs[KEY_REGION] = settings.region.trim()
             prefs[KEY_REGION_REQUEST_SENT_AT] = settings.regionRequestSentAt
             if (settings.supportId.isNotBlank()) {
@@ -558,6 +560,7 @@ class SettingsRepository(context: Context) {
         }
         val KEY_SUPPORT_ID = stringPreferencesKey("support_id")
         val KEY_CRASH_REPORTING = booleanPreferencesKey("crash_reporting_enabled")
+        val KEY_DIAGNOSTIC_LOGGING = booleanPreferencesKey("diagnostic_logging_enabled")
         val KEY_REGION = stringPreferencesKey("app_region")
         val KEY_REGION_REQUEST_SENT_AT = longPreferencesKey("region_request_sent_at")
         val KEY_LAST_HEARTBEAT_DAY = stringPreferencesKey("sentry_last_heartbeat_utc_day")

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/MainScreen.kt
@@ -395,6 +395,16 @@ fun MainScreen(
                 onCrashReportingChange = { enabled ->
                     viewModel.setCrashReportingEnabled(enabled)
                 },
+                onStartDiagnosticLogging = {
+                    viewModel.setDiagnosticLoggingEnabled(true)
+                },
+                onStopAndExportDiagnosticLog = {
+                    val ok = viewModel.stopDiagnosticLoggingAndExport(context)
+                    SystemToast.show(
+                        context,
+                        if (ok) "Choose an app to share the log" else "No diagnostic log yet",
+                    )
+                },
                 onHeartDoubleTapHeartbeat = viewModel::sendHeartbeatFromLoveTap,
                 onSupportIdCopied = {
                     SystemToast.show(context, "Support ID copied")

--- a/app/src/main/java/com/anant/fitbuddy/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/screens/SettingsScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TimePicker
 import androidx.compose.material3.rememberTimePickerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -112,6 +113,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.anant.fitbuddy.BuildConfig
+import com.anant.fitbuddy.util.DiagnosticLogger
 import com.anant.fitbuddy.data.database.UserProfile
 import com.anant.fitbuddy.data.model.ModelOption
 import com.anant.fitbuddy.data.model.OpenAiCatalog
@@ -189,6 +191,8 @@ fun SettingsScreen(
     onCheckForUpdates: () -> Unit,
     onAutoCheckUpdatesChange: (Boolean) -> Unit,
     onCrashReportingChange: (Boolean) -> Unit,
+    onStartDiagnosticLogging: () -> Unit = {},
+    onStopAndExportDiagnosticLog: () -> Unit = {},
     onSupportIdCopied: () -> Unit = {},
     onDeveloperUnlockHint: (remainingTaps: Int) -> Unit = {},
     onDeveloperUnlockHintDismiss: () -> Unit = {},
@@ -1266,6 +1270,55 @@ fun SettingsScreen(
                     "(Cron, Metrics, and Logs — not Issues). Turn off anytime. " +
                     "Your Support ID (under Backup) identifies reports without personal data."
             )
+            val diagnosticEntries by DiagnosticLogger.entryCount.collectAsState()
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "Diagnostic log",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.weight(1f)
+                )
+                HintIconButton(
+                    title = "Diagnostic log",
+                    message = "Captures AI connection steps (provider, model, HTTP status) so you can " +
+                        "share them when something fails. No meals, photos, or API keys. " +
+                        "Start logging, reproduce the issue, then stop & export."
+                )
+            }
+            Text(
+                text = when {
+                    settings.diagnosticLoggingEnabled && diagnosticEntries > 0 ->
+                        "Logging… $diagnosticEntries lines — stop & export when done"
+                    settings.diagnosticLoggingEnabled ->
+                        "Logging… reproduce the issue, then stop & export"
+                    diagnosticEntries > 0 ->
+                        "$diagnosticEntries lines from last session"
+                    else ->
+                        "Off until you start logging"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            OutlinedButton(
+                onClick = {
+                    if (settings.diagnosticLoggingEnabled) {
+                        onStopAndExportDiagnosticLog()
+                    } else {
+                        onStartDiagnosticLogging()
+                    }
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                if (settings.diagnosticLoggingEnabled) {
+                    Icon(Icons.Filled.FileUpload, contentDescription = null)
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Text("Stop logging & export")
+                } else {
+                    Text("Start logging")
+                }
+            }
         }
 
         // --- About -----------------------------------------------------------------------

--- a/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/anant/fitbuddy/ui/viewmodel/MainViewModel.kt
@@ -35,6 +35,8 @@ import com.anant.fitbuddy.data.model.ScannedProduct
 import com.anant.fitbuddy.data.model.TargetPlanResponse
 import com.anant.fitbuddy.data.model.WorkoutDraft
 import com.anant.fitbuddy.crash.CrashReporter
+import com.anant.fitbuddy.util.BackupShare
+import com.anant.fitbuddy.util.DiagnosticLogger
 import com.anant.fitbuddy.crash.HeartbeatInfo
 import com.anant.fitbuddy.crash.HeartbeatKind
 import com.anant.fitbuddy.data.remote.RemoteAiDataSource
@@ -52,7 +54,6 @@ import com.anant.fitbuddy.data.settings.FailoverLadders
 import com.anant.fitbuddy.data.settings.ModelCooldown
 import com.anant.fitbuddy.data.settings.SettingsRepository
 import com.anant.fitbuddy.data.remote.dto.ModelCatalogModality
-import com.anant.fitbuddy.util.BackupShare
 import com.anant.fitbuddy.util.DateUtils
 import com.anant.fitbuddy.util.ProgressMetricsCompressor
 import kotlinx.coroutines.Dispatchers
@@ -739,6 +740,41 @@ class MainViewModel(
             }
         }
     }
+
+    fun setDiagnosticLoggingEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            val current = settings.value
+            settingsRepository.save(current.copy(diagnosticLoggingEnabled = enabled))
+            DiagnosticLogger.setEnabled(enabled, current, restartSession = enabled)
+            _analysisState.update {
+                it.copy(
+                    userMessage = if (enabled) {
+                        "Diagnostic logging on — reproduce the issue, then stop & export"
+                    } else {
+                        "Diagnostic logging off"
+                    }
+                )
+            }
+        }
+    }
+
+    /** Stops recording (keeps the buffer) and opens the share sheet for the log file. */
+    fun stopDiagnosticLoggingAndExport(context: Context): Boolean {
+        DiagnosticLogger.setEnabled(false, restartSession = false)
+        viewModelScope.launch {
+            val current = settings.value
+            if (current.diagnosticLoggingEnabled) {
+                settingsRepository.save(current.copy(diagnosticLoggingEnabled = false))
+            }
+            _analysisState.update { it.copy(userMessage = "Diagnostic logging stopped") }
+        }
+        val file = DiagnosticLogger.exportToShareFile(context) ?: return false
+        return runCatching {
+            BackupShare.shareTextFile(context, file, chooserTitle = "Share diagnostic log")
+            true
+        }.getOrDefault(false)
+    }
+
 
     /**
      * Easter egg: Settings “crafted with ♥” double-tap. Always tries a Sentry heartbeat

--- a/app/src/main/java/com/anant/fitbuddy/util/BackupShare.kt
+++ b/app/src/main/java/com/anant/fitbuddy/util/BackupShare.kt
@@ -7,10 +7,23 @@ import java.io.File
 
 object BackupShare {
     fun shareJsonFile(context: Context, file: File, chooserTitle: String = "Share backup") {
+        shareFile(context, file, mimeType = "application/json", chooserTitle = chooserTitle)
+    }
+
+    fun shareTextFile(context: Context, file: File, chooserTitle: String = "Share log") {
+        shareFile(context, file, mimeType = "text/plain", chooserTitle = chooserTitle)
+    }
+
+    private fun shareFile(
+        context: Context,
+        file: File,
+        mimeType: String,
+        chooserTitle: String
+    ) {
         val authority = "${context.packageName}.fileprovider"
         val uri = FileProvider.getUriForFile(context, authority, file)
         val send = Intent(Intent.ACTION_SEND).apply {
-            type = "application/json"
+            type = mimeType
             putExtra(Intent.EXTRA_STREAM, uri)
             putExtra(Intent.EXTRA_SUBJECT, file.name)
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)

--- a/app/src/main/java/com/anant/fitbuddy/util/DiagnosticLogger.kt
+++ b/app/src/main/java/com/anant/fitbuddy/util/DiagnosticLogger.kt
@@ -1,0 +1,175 @@
+package com.anant.fitbuddy.util
+
+import android.content.Context
+import android.net.Uri
+import android.os.Build
+import com.anant.fitbuddy.BuildConfig
+import com.anant.fitbuddy.data.settings.AppSettings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+/**
+ * Opt-in support log for AI connection troubleshooting. Captures provider/model/HTTP
+ * breadcrumbs only — never meal text, photos, or API keys. Survives process death while
+ * enabled so users can reproduce an issue then export from Settings.
+ */
+object DiagnosticLogger {
+
+    private const val MAX_LINES = 400
+    private const val MAX_LINE_CHARS = 500
+    private const val DIR = "diagnostics"
+    private const val FILE_NAME = "session.log"
+
+    @Volatile
+    private var enabled: Boolean = false
+    @Volatile
+    private var filesDir: File? = null
+
+    private val lock = Any()
+    private val lines = ArrayDeque<String>(MAX_LINES + 1)
+    private val _entryCount = MutableStateFlow(0)
+    val entryCount: StateFlow<Int> = _entryCount.asStateFlow()
+
+    private val isoFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.US).apply {
+        timeZone = TimeZone.getTimeZone("UTC")
+    }
+
+    fun init(context: Context) {
+        filesDir = File(context.applicationContext.filesDir, DIR).also { it.mkdirs() }
+        synchronized(lock) {
+            loadFromDiskLocked()
+        }
+    }
+
+    fun isEnabled(): Boolean = enabled
+
+    /**
+     * Turn logging on/off. When [restartSession] is true (user toggle on), clears any prior
+     * session and writes a metadata header. Disabling keeps the buffer so the user can export.
+     * App startup should call with [restartSession]=false to resume an existing session file.
+     */
+    fun setEnabled(
+        value: Boolean,
+        settings: AppSettings? = null,
+        restartSession: Boolean = true
+    ) {
+        enabled = value
+        if (value && restartSession) {
+            clear()
+            if (settings != null) startSession(settings)
+        }
+    }
+
+    fun clear() {
+        synchronized(lock) {
+            lines.clear()
+            _entryCount.value = 0
+            logFile()?.delete()
+        }
+    }
+
+    fun hasContent(): Boolean = synchronized(lock) { lines.isNotEmpty() }
+
+    fun log(category: String, message: String, details: Map<String, String> = emptyMap()) {
+        if (!enabled) return
+        val ts = isoFormat.format(Date())
+        val detailPart = details.entries
+            .joinToString(" ") { (k, v) -> "$k=${scrub(v)}" }
+            .takeIf { it.isNotBlank() }
+        val raw = buildString {
+            append(ts)
+            append(' ')
+            append(scrub(category))
+            append(": ")
+            append(scrub(message))
+            if (detailPart != null) {
+                append(" | ")
+                append(detailPart)
+            }
+        }.take(MAX_LINE_CHARS)
+        appendLine(raw)
+    }
+
+    /**
+     * Writes a shareable copy under cache/share/ and returns it for [BackupShare].
+     * Returns null when there is nothing to export.
+     */
+    fun exportToShareFile(context: Context): File? {
+        val body = synchronized(lock) {
+            if (lines.isEmpty()) return null
+            lines.joinToString("\n") + "\n"
+        }
+        val dir = File(context.cacheDir, "share").apply { mkdirs() }
+        val stamp = SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(Date())
+        val out = File(dir, "FitBuddy-diagnostics-$stamp.txt")
+        out.writeText(body)
+        return out
+    }
+
+    fun hostOf(url: String): String =
+        runCatching { Uri.parse(url).host }
+            .getOrNull()
+            ?.takeIf { it.isNotBlank() }
+            ?: url.take(80)
+
+    fun scrub(value: String): String {
+        var s = value
+        s = Regex("(?i)(bearer\\s+)\\S+").replace(s) { "${it.groupValues[1]}[redacted]" }
+        s = Regex("(?i)(sk-[A-Za-z0-9_-]{8,})").replace(s, "[redacted-key]")
+        s = Regex("(?i)(AIza[A-Za-z0-9_-]{8,})").replace(s, "[redacted-key]")
+        s = Regex("(?i)(api[_-]?key[=:]\\s*)\\S+").replace(s) { "${it.groupValues[1]}[redacted]" }
+        s = Regex("eyJ[A-Za-z0-9_-]{20,}").replace(s, "[redacted-jwt]")
+        s = Regex("data:image/[^;]+;base64,[A-Za-z0-9+/=]+").replace(s, "[image-omitted]")
+        return s.take(MAX_LINE_CHARS)
+    }
+
+    private fun startSession(settings: AppSettings) {
+        appendLine("=== FitBuddy diagnostic log ===")
+        appendLine("started_utc=${isoFormat.format(Date())}")
+        appendLine("app=${BuildConfig.APPLICATION_ID} ${BuildConfig.VERSION_NAME}+${BuildConfig.VERSION_CODE}")
+        appendLine("android_sdk=${Build.VERSION.SDK_INT} ${Build.MANUFACTURER} ${Build.MODEL}")
+        appendLine("support_id=${settings.supportId.ifBlank { "(none)" }}")
+        appendLine("provider=${settings.provider.name}")
+        appendLine("auto_failover=${settings.autoFailoverFor(settings.provider)}")
+        appendLine("show_paid=${settings.showPaidFor(settings.provider)}")
+        appendLine("photo_model=${scrub(settings.model)}")
+        appendLine("text_model=${scrub(settings.textModel)}")
+        appendLine("chat_host=${hostOf(settings.chatUrl)}")
+        appendLine("configured=${settings.isConfigured}")
+        appendLine("keys_count=${settings.keysFor(settings.provider).size}")
+        appendLine("--- events ---")
+    }
+
+    private fun appendLine(line: String) {
+        synchronized(lock) {
+            while (lines.size >= MAX_LINES) {
+                lines.removeFirst()
+            }
+            lines.addLast(line)
+            _entryCount.value = lines.size
+            persistLocked()
+        }
+    }
+
+    private fun logFile(): File? = filesDir?.let { File(it, FILE_NAME) }
+
+    private fun persistLocked() {
+        val file = logFile() ?: return
+        file.writeText(lines.joinToString("\n") + "\n")
+    }
+
+    private fun loadFromDiskLocked() {
+        val file = logFile() ?: return
+        if (!file.exists()) return
+        val loaded = file.readLines().filter { it.isNotBlank() }
+        lines.clear()
+        loaded.takeLast(MAX_LINES).forEach { lines.addLast(it) }
+        _entryCount.value = lines.size
+    }
+}

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -17,6 +17,7 @@ Features:
 • Offline fallback — works without an AI key via built-in simulator
 • Material You — dynamic color theming on Android 12+
 • Crash reports — optional anonymous Sentry reports (off by default; opt in via Settings)
+• Diagnostic log — optional AI connection log you can export from Settings for support (no meals, photos, or keys)
 
 AI providers (configured at runtime in Settings):
 • OpenRouter — free vision models, automatic model dropdown


### PR DESCRIPTION
## Summary
- Adds a Settings → Updates & support control to **Start logging** / **Stop logging & export** for AI connection troubleshooting (no developer unlock).
- Captures provider, model, host, HTTP/network errors, and failover attempts — never meals, photos, or API keys.
- Updates store full description to mention the diagnostic log.

## Test plan
- [ ] Settings → Updates & support: Start logging → trigger a meal/workout AI request that fails → Stop logging & export → share sheet opens with a `.txt` log
- [ ] Confirm log includes analyze start + http/network error (or failover) lines and no API keys / meal text
- [ ] Start logging, force-kill app, reopen: logging still on and prior lines retained until stop/export
- [ ] Crash reports toggle and other Settings cards still work